### PR TITLE
ApproxEq trait enhanced with ULPs method of specifying closeness:

### DIFF
--- a/src/macros/assert.rs
+++ b/src/macros/assert.rs
@@ -18,11 +18,11 @@ macro_rules! assert_approx_eq_eps(
 #[macro_export]
 macro_rules! assert_approx_eq_ulps(
     ($given: expr, $expected: expr, $ulps: expr) => ({
-        let ulps = &($ulps);
+        let ulps = $ulps;
         let (given_val, expected_val) = (&($given), &($expected));
         if !ApproxEq::approx_eq_ulps(given_val, expected_val, ulps) {
             panic!("assertion failed: `left ≈ right` (left: `{}`, right: `{}`, tolerance: `{}`)",
-                *given_val, *expected_val, *ulps
+                *given_val, *expected_val, ulps
             )
         }
     })

--- a/src/macros/assert.rs
+++ b/src/macros/assert.rs
@@ -13,6 +13,21 @@ macro_rules! assert_approx_eq_eps(
     })
 );
 
+/// Asserts approximate equality within a given tolerance of two values with the
+/// `ApproxEq` trait, with tolerance specified in ULPs.
+#[macro_export]
+macro_rules! assert_approx_eq_ulps(
+    ($given: expr, $expected: expr, $ulps: expr) => ({
+        let ulps = &($ulps);
+        let (given_val, expected_val) = (&($given), &($expected));
+        if !ApproxEq::approx_eq_ulps(given_val, expected_val, ulps) {
+            panic!("assertion failed: `left ≈ right` (left: `{}`, right: `{}`, tolerance: `{}`)",
+                *given_val, *expected_val, *ulps
+            )
+        }
+    })
+);
+
 /// Asserts approximate equality of two values with the `ApproxEq` trait.
 #[macro_export]
 macro_rules! assert_approx_eq(

--- a/src/structs/dmat.rs
+++ b/src/structs/dmat.rs
@@ -604,9 +604,20 @@ impl<N: ApproxEq<N>> ApproxEq<N> for DMat<N> {
     }
 
     #[inline]
+    fn approx_ulps(_: Option<DMat<N>>) -> u32 {
+        ApproxEq::approx_ulps(None::<N>)
+    }
+
+    #[inline]
     fn approx_eq_eps(&self, other: &DMat<N>, epsilon: &N) -> bool {
         let zip = self.mij.iter().zip(other.mij.iter());
         zip.all(|(a, b)| ApproxEq::approx_eq_eps(a, b, epsilon))
+    }
+
+    #[inline]
+    fn approx_eq_ulps(&self, other: &DMat<N>, ulps: u32) -> bool {
+        let zip = self.mij.iter().zip(other.mij.iter());
+        zip.all(|(a, b)| ApproxEq::approx_eq_ulps(a, b, ulps))
     }
 }
 

--- a/src/structs/dvec_macros.rs
+++ b/src/structs/dvec_macros.rs
@@ -301,9 +301,20 @@ macro_rules! dvec_impl(
             }
 
             #[inline]
+            fn approx_ulps(_: Option<$dvec<N>>) -> u32 {
+                ApproxEq::approx_ulps(None::<N>)
+            }
+
+            #[inline]
             fn approx_eq_eps(&self, other: &$dvec<N>, epsilon: &N) -> bool {
                 let zip = self.as_slice().iter().zip(other.as_slice().iter());
                 zip.all(|(a, b)| ApproxEq::approx_eq_eps(a, b, epsilon))
+            }
+
+            #[inline]
+            fn approx_eq_ulps(&self, other: &$dvec<N>, ulps: u32) -> bool {
+                let zip = self.as_slice().iter().zip(other.as_slice().iter());
+                zip.all(|(a, b)| ApproxEq::approx_eq_ulps(a, b, ulps))
             }
         }
 

--- a/src/structs/iso_macros.rs
+++ b/src/structs/iso_macros.rs
@@ -317,9 +317,20 @@ macro_rules! approx_eq_impl(
             }
 
             #[inline]
+            fn approx_ulps(_: Option<$t<N>>) -> u32 {
+                ApproxEq::approx_ulps(None::<N>)
+            }
+
+            #[inline]
             fn approx_eq_eps(&self, other: &$t<N>, epsilon: &N) -> bool {
                 ApproxEq::approx_eq_eps(&self.rotation, &other.rotation, epsilon) &&
                     ApproxEq::approx_eq_eps(&self.translation, &other.translation, epsilon)
+            }
+
+            #[inline]
+            fn approx_eq_ulps(&self, other: &$t<N>, ulps: u32) -> bool {
+                ApproxEq::approx_eq_ulps(&self.rotation, &other.rotation, ulps) &&
+                    ApproxEq::approx_eq_ulps(&self.translation, &other.translation, ulps)
             }
         }
     )

--- a/src/structs/mat_macros.rs
+++ b/src/structs/mat_macros.rs
@@ -623,9 +623,20 @@ macro_rules! approx_eq_impl(
         }
 
         #[inline]
+        fn approx_ulps(_: Option<$t<N>>) -> u32 {
+            ApproxEq::approx_ulps(None::<N>)
+        }
+
+        #[inline]
         fn approx_eq_eps(&self, other: &$t<N>, epsilon: &N) -> bool {
             let zip = self.iter().zip(other.iter());
             zip.all(|(a, b)| ApproxEq::approx_eq_eps(a, b, epsilon))
+        }
+
+        #[inline]
+        fn approx_eq_ulps(&self, other: &$t<N>, ulps: u32) -> bool {
+            let zip = self.iter().zip(other.iter());
+            zip.all(|(a, b)| ApproxEq::approx_eq_ulps(a, b, ulps))
         }
     }
   )

--- a/src/structs/quat.rs
+++ b/src/structs/quat.rs
@@ -290,8 +290,18 @@ impl<N: ApproxEq<N>> ApproxEq<N> for UnitQuat<N> {
     }
 
     #[inline]
+    fn approx_ulps(_: Option<UnitQuat<N>>) -> u32 {
+        ApproxEq::approx_ulps(None::<N>)
+    }
+
+    #[inline]
     fn approx_eq_eps(&self, other: &UnitQuat<N>, eps: &N) -> bool {
         ApproxEq::approx_eq_eps(&self.q, &other.q, eps)
+    }
+
+    #[inline]
+    fn approx_eq_ulps(&self, other: &UnitQuat<N>, ulps: u32) -> bool {
+        ApproxEq::approx_eq_ulps(&self.q, &other.q, ulps)
     }
 }
 

--- a/src/structs/rot_macros.rs
+++ b/src/structs/rot_macros.rs
@@ -257,6 +257,11 @@ macro_rules! approx_eq_impl(
             }
 
             #[inline]
+            fn approx_ulps(_: Option<$t<N>>) -> u32 {
+                ApproxEq::approx_ulps(None::<N>)
+            }
+
+            #[inline]
             fn approx_eq(&self, other: &$t<N>) -> bool {
                 ApproxEq::approx_eq(&self.submat, &other.submat)
             }
@@ -264,6 +269,11 @@ macro_rules! approx_eq_impl(
             #[inline]
             fn approx_eq_eps(&self, other: &$t<N>, epsilon: &N) -> bool {
                 ApproxEq::approx_eq_eps(&self.submat, &other.submat, epsilon)
+            }
+
+            #[inline]
+            fn approx_eq_ulps(&self, other: &$t<N>, ulps: u32) -> bool {
+                ApproxEq::approx_eq_ulps(&self.submat, &other.submat, ulps)
             }
         }
     )

--- a/src/structs/spec/vec0.rs
+++ b/src/structs/spec/vec0.rs
@@ -204,8 +204,17 @@ impl<N: ApproxEq<N>> ApproxEq<N> for vec::Vec0<N> {
         ApproxEq::approx_epsilon(None::<N>)
     }
 
+    fn approx_ulps(_: Option<vec::Vec0<N>>) -> u32 {
+        ApproxEq::approx_ulps(None::<N>)
+    }
+
     #[inline]
     fn approx_eq_eps(&self, _: &vec::Vec0<N>, _: &N) -> bool {
+        true
+    }
+
+    #[inline]
+    fn approx_eq_ulps(&self, _: &vec::Vec0<N>, _: u32) -> bool {
         true
     }
 }

--- a/src/structs/vec_macros.rs
+++ b/src/structs/vec_macros.rs
@@ -610,6 +610,11 @@ macro_rules! approx_eq_impl(
             }
 
             #[inline]
+            fn approx_ulps(_: Option<$t<N>>) -> u32 {
+                ApproxEq::approx_ulps(None::<N>)
+            }
+
+            #[inline]
             fn approx_eq(&self, other: &$t<N>) -> bool {
                 ApproxEq::approx_eq(&self.$comp0, &other.$comp0)
                 $(&& ApproxEq::approx_eq(&self.$compN, &other.$compN))*
@@ -619,6 +624,12 @@ macro_rules! approx_eq_impl(
             fn approx_eq_eps(&self, other: &$t<N>, eps: &N) -> bool {
                 ApproxEq::approx_eq_eps(&self.$comp0, &other.$comp0, eps)
                 $(&& ApproxEq::approx_eq_eps(&self.$compN, &other.$compN, eps))*
+            }
+
+            #[inline]
+            fn approx_eq_ulps(&self, other: &$t<N>, ulps: u32) -> bool {
+                ApproxEq::approx_eq_ulps(&self.$comp0, &other.$comp0, ulps)
+                $(&& ApproxEq::approx_eq_ulps(&self.$compN, &other.$compN, ulps))*
             }
         }
     )

--- a/tests/assert.rs
+++ b/tests/assert.rs
@@ -33,3 +33,36 @@ fn assert_approx_eq_eps_f32() {
 fn assert_approx_eq_eps_f64_fail() {
     assert_approx_eq_eps!(1.0f64, 1.1, 0.05);
 }
+
+#[test]
+fn assert_approx_eq_ulps_f32() {
+    let x = 1000000_f32;
+    let y = 1000000.1_f32;
+    assert!(x != y);
+    assert_approx_eq_ulps!(x, y, 3);
+}
+
+#[test]
+#[should_fail]
+fn assert_approx_eq_ulps_f32_fail() {
+    let x = 1000000_f32;
+    let y = 1000000.1_f32;
+    assert_approx_eq_ulps!(x, y, 2);
+}
+
+#[test]
+fn assert_approx_eq_ulps_f64() {
+    let x = 1000000_f64;
+    let y = 1000000.0000000003_f64;
+    assert!(x != y);
+    assert_approx_eq_ulps!(x, y, 4);
+}
+
+#[test]
+#[should_fail]
+fn assert_approx_eq_ulps_f64_fail() {
+    let x = 1000000_f64;
+    let y = 1000000.0000000003_f64;
+    assert!(x != y);
+    assert_approx_eq_ulps!(x, y, 3);
+}


### PR DESCRIPTION
See issue #60.
Background reading:  https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/

  approx_eq_ulps() allows specification of epsilon as an integer number
  of Units in the Last Place (ULPs) difference between the two floating
  point values

  default approx_ulps() is set to 8.

  approx_eq() function continues to use epsilon method, although I
  recommend further commits and a migration towards the ULPs method.