### PR TITLE
Update to latest Rust

### DIFF
--- a/src/structs/dvec.rs
+++ b/src/structs/dvec.rs
@@ -82,7 +82,7 @@ dvec_impl!(DVec);
 
 /// Stack-allocated, dynamically sized vector with a maximum size of 1.
 pub struct DVec1<N> {
-    at:  [N, ..1],
+    at:  [N; 1],
     dim: uint
 }
 
@@ -92,7 +92,7 @@ small_dvec_from_impl!(DVec1, 1, ::zero());
 
 /// Stack-allocated, dynamically sized vector with a maximum size of 2.
 pub struct DVec2<N> {
-    at:  [N, ..2],
+    at:  [N; 2],
     dim: uint
 }
 
@@ -102,7 +102,7 @@ small_dvec_from_impl!(DVec2, 2, ::zero(), ::zero());
 
 /// Stack-allocated, dynamically sized vector with a maximum size of 3.
 pub struct DVec3<N> {
-    at:  [N, ..3],
+    at:  [N; 3],
     dim: uint
 }
 
@@ -112,7 +112,7 @@ small_dvec_from_impl!(DVec3, 3, ::zero(), ::zero(), ::zero());
 
 /// Stack-allocated, dynamically sized vector with a maximum size of 4.
 pub struct DVec4<N> {
-    at:  [N, ..4],
+    at:  [N; 4],
     dim: uint
 }
 
@@ -122,7 +122,7 @@ small_dvec_from_impl!(DVec4, 4, ::zero(), ::zero(), ::zero(), ::zero());
 
 /// Stack-allocated, dynamically sized vector with a maximum size of 5.
 pub struct DVec5<N> {
-    at:  [N, ..5],
+    at:  [N; 5],
     dim: uint
 }
 
@@ -132,7 +132,7 @@ small_dvec_from_impl!(DVec5, 5, ::zero(), ::zero(), ::zero(), ::zero(), ::zero()
 
 /// Stack-allocated, dynamically sized vector with a maximum size of 6.
 pub struct DVec6<N> {
-    at:  [N, ..6],
+    at:  [N; 6],
     dim: uint
 }
 

--- a/src/structs/dvec_macros.rs
+++ b/src/structs/dvec_macros.rs
@@ -389,7 +389,7 @@ macro_rules! small_dvec_impl (
 
         impl<N: Clone> Clone for $dvec<N> {
             fn clone(&self) -> $dvec<N> {
-                let at: [N, ..$dim] = [ $( self.at[$idx].clone(), )* ];
+                let at: [N; $dim] = [ $( self.at[$idx].clone(), )* ];
 
                 $dvec {
                     at:  at,
@@ -410,7 +410,7 @@ macro_rules! small_dvec_from_impl (
             pub fn from_elem(dim: uint, elem: N) -> $dvec<N> {
                 assert!(dim <= $dim);
 
-                let mut at: [N, ..$dim] = [ $( $zeros, )* ];
+                let mut at: [N; $dim] = [ $( $zeros, )* ];
 
                 for n in at.slice_to_mut(dim).iter_mut() {
                     *n = elem;
@@ -432,7 +432,7 @@ macro_rules! small_dvec_from_impl (
                 assert!(dim <= vec.len() && dim <= $dim);
 
                 // FIXME: not safe.
-                let mut at: [N, ..$dim] = [ $( $zeros, )* ];
+                let mut at: [N; $dim] = [ $( $zeros, )* ];
 
                 for (curr, other) in vec.iter().zip(at.iter_mut()) {
                     *other = *curr;
@@ -451,7 +451,7 @@ macro_rules! small_dvec_from_impl (
             pub fn from_fn(dim: uint, f: |uint| -> N) -> $dvec<N> {
                 assert!(dim <= $dim);
 
-                let mut at: [N, ..$dim] = [ $( $zeros, )* ];
+                let mut at: [N; $dim] = [ $( $zeros, )* ];
 
                 for i in range(0, dim) {
                     at[i] = f(i);
@@ -467,7 +467,7 @@ macro_rules! small_dvec_from_impl (
         impl<N: Zero> FromIterator<N> for $dvec<N> {
             #[inline]
             fn from_iter<I: Iterator<N>>(mut param: I) -> $dvec<N> {
-                let mut at: [N, ..$dim] = [ $( $zeros, )* ];
+                let mut at: [N; $dim] = [ $( $zeros, )* ];
 
                 let mut dim = 0;
 

--- a/src/structs/mat_macros.rs
+++ b/src/structs/mat_macros.rs
@@ -19,7 +19,7 @@ macro_rules! as_array_impl(
         impl<N> $t<N> {
             /// View this matrix as a column-major array of arrays.
             #[inline]
-            pub fn as_array(&self) -> &[[N, ..$dim], ..$dim] {
+            pub fn as_array(&self) -> &[[N; $dim]; $dim] {
                 unsafe {
                     mem::transmute(self)
                 }
@@ -27,7 +27,7 @@ macro_rules! as_array_impl(
 
             /// View this matrix as a column-major mutable array of arrays.
             #[inline]
-            pub fn as_array_mut<'a>(&'a mut self) -> &'a mut [[N, ..$dim], ..$dim] {
+            pub fn as_array_mut<'a>(&'a mut self) -> &'a mut [[N; $dim]; $dim] {
                 unsafe {
                     mem::transmute(self)
                 }
@@ -36,11 +36,11 @@ macro_rules! as_array_impl(
             // FIXME: because of https://github.com/rust-lang/rust/issues/16418 we cannot do the
             // array-to-mat conversion by-value:
             //
-            // pub fn from_array(array: [N, ..$dim]) -> $t<N>
+            // pub fn from_array(array: [N; $dim]) -> $t<N>
 
             /// View a column-major array of array as a vector.
             #[inline]
-            pub fn from_array_ref(array: &[[N, ..$dim], ..$dim]) -> &$t<N> {
+            pub fn from_array_ref(array: &[[N; $dim]; $dim]) -> &$t<N> {
                 unsafe {
                     mem::transmute(array)
                 }
@@ -48,7 +48,7 @@ macro_rules! as_array_impl(
 
             /// View a column-major array of array as a mutable vector.
             #[inline]
-            pub fn from_array_mut(array: &mut [[N, ..$dim], ..$dim]) -> &mut $t<N> {
+            pub fn from_array_mut(array: &mut [[N; $dim]; $dim]) -> &mut $t<N> {
                 unsafe {
                     mem::transmute(array)
                 }
@@ -62,13 +62,13 @@ macro_rules! at_fast_impl(
         impl<N: Copy> $t<N> {
             #[inline]
             pub unsafe fn at_fast(&self, (i, j): (uint, uint)) -> N {
-                (*mem::transmute::<&$t<N>, &[N, ..$dim * $dim]>(self)
+                (*mem::transmute::<&$t<N>, &[N; $dim * $dim]>(self)
                  .unsafe_get(i + j * $dim))
             }
 
             #[inline]
             pub unsafe fn set_fast(&mut self, (i, j): (uint, uint), val: N) {
-                (*mem::transmute::<&mut $t<N>, &mut [N, ..$dim * $dim]>(self)
+                (*mem::transmute::<&mut $t<N>, &mut [N; $dim * $dim]>(self)
                  .get_unchecked_mut(i + j * $dim)) = val
             }
         }
@@ -183,7 +183,7 @@ macro_rules! iterable_impl(
         #[inline]
         fn iter<'l>(&'l self) -> Iter<'l, N> {
             unsafe {
-                mem::transmute::<&'l $t<N>, &'l [N, ..$dim * $dim]>(self).iter()
+                mem::transmute::<&'l $t<N>, &'l [N; $dim * $dim]>(self).iter()
             }
         }
     }
@@ -196,7 +196,7 @@ macro_rules! iterable_mut_impl(
         #[inline]
         fn iter_mut<'l>(&'l mut self) -> IterMut<'l, N> {
             unsafe {
-                mem::transmute::<&'l mut $t<N>, &'l mut [N, ..$dim * $dim]>(self).iter_mut()
+                mem::transmute::<&'l mut $t<N>, &'l mut [N; $dim * $dim]>(self).iter_mut()
             }
         }
     }
@@ -257,33 +257,33 @@ macro_rules! indexable_impl(
         #[inline]
         fn at(&self, (i, j): (uint, uint)) -> N {
             unsafe {
-                mem::transmute::<&$t<N>, &[N, ..$dim * $dim]>(self)[i + j * $dim]
+                mem::transmute::<&$t<N>, &[N; $dim * $dim]>(self)[i + j * $dim]
             }
         }
 
         #[inline]
         fn set(&mut self, (i, j): (uint, uint), val: N) {
             unsafe {
-                mem::transmute::<&mut $t<N>, &mut [N, ..$dim * $dim]>(self)[i + j * $dim] = val
+                mem::transmute::<&mut $t<N>, &mut [N; $dim * $dim]>(self)[i + j * $dim] = val
             }
         }
 
         #[inline]
         fn swap(&mut self, (i1, j1): (uint, uint), (i2, j2): (uint, uint)) {
             unsafe {
-              mem::transmute::<&mut $t<N>, &mut [N, ..$dim * $dim]>(self)
+              mem::transmute::<&mut $t<N>, &mut [N; $dim * $dim]>(self)
                 .swap(i1 + j1 * $dim, i2 + j2 * $dim)
             }
         }
 
         #[inline]
         unsafe fn unsafe_at(&self, (i, j): (uint, uint)) -> N {
-            (*mem::transmute::<&$t<N>, &[N, ..$dim * $dim]>(self).unsafe_get(i + j * $dim))
+            (*mem::transmute::<&$t<N>, &[N; $dim * $dim]>(self).unsafe_get(i + j * $dim))
         }
 
         #[inline]
         unsafe fn unsafe_set(&mut self, (i, j): (uint, uint), val: N) {
-            (*mem::transmute::<&mut $t<N>, &mut [N, ..$dim * $dim]>(self).get_unchecked_mut(i + j * $dim)) = val
+            (*mem::transmute::<&mut $t<N>, &mut [N; $dim * $dim]>(self).get_unchecked_mut(i + j * $dim)) = val
         }
     }
   )
@@ -294,7 +294,7 @@ macro_rules! index_impl(
         impl<N> Index<(uint, uint), N> for $t<N> {
             fn index(&self, &(i, j): &(uint, uint)) -> &N {
                 unsafe {
-                    &mem::transmute::<&$t<N>, &mut [N, ..$dim * $dim]>(self)[i + j * $dim]
+                    &mem::transmute::<&$t<N>, &mut [N; $dim * $dim]>(self)[i + j * $dim]
                 }
             }
         }
@@ -302,7 +302,7 @@ macro_rules! index_impl(
         impl<N> IndexMut<(uint, uint), N> for $t<N> {
             fn index_mut(&mut self, &(i, j): &(uint, uint)) -> &mut N {
                 unsafe {
-                    &mut mem::transmute::<&mut $t<N>, &mut [N, ..$dim * $dim]>(self)[i + j * $dim]
+                    &mut mem::transmute::<&mut $t<N>, &mut [N; $dim * $dim]>(self)[i + j * $dim]
                 }
             }
         }

--- a/src/structs/spec/vec.rs
+++ b/src/structs/spec/vec.rs
@@ -153,7 +153,7 @@ impl<N: BaseFloat> Basis for Vec3<N> {
 }
 
 // FIXME: this bad: this fixes definitly the number of samples…
-static SAMPLES_2_F64: [Vec2<f64>, ..21] = [
+static SAMPLES_2_F64: [Vec2<f64>; 21] = [
     Vec2 { x: 1.0,         y: 0.0         },
     Vec2 { x: 0.95557281,  y: 0.29475517  },
     Vec2 { x: 0.82623877,  y: 0.56332006  },
@@ -178,7 +178,7 @@ static SAMPLES_2_F64: [Vec2<f64>, ..21] = [
 ];
 
 // Those vectors come from bullet 3d
-static SAMPLES_3_F64: [Vec3<f64>, ..42] = [
+static SAMPLES_3_F64: [Vec3<f64>; 42] = [
     Vec3 { x: 0.000000 , y: -0.000000, z: -1.000000 },
     Vec3 { x: 0.723608 , y: -0.525725, z: -0.447219 },
     Vec3 { x: -0.276388, y: -0.850649, z: -0.447219 },

--- a/src/structs/spec/vec0.rs
+++ b/src/structs/spec/vec0.rs
@@ -67,14 +67,14 @@ impl<N> Indexable<uint, N> for vec::Vec0<N> {
 impl<N: 'static> Iterable<N> for vec::Vec0<N> {
     #[inline]
     fn iter<'l>(&'l self) -> Iter<'l, N> {
-        unsafe { mem::transmute::<&'l vec::Vec0<N>, &'l [N, ..0]>(self).iter() }
+        unsafe { mem::transmute::<&'l vec::Vec0<N>, &'l [N; 0]>(self).iter() }
     }
 }
 
 impl<N: 'static> IterableMut<N> for vec::Vec0<N> {
     #[inline]
     fn iter_mut<'l>(&'l mut self) -> IterMut<'l, N> {
-        unsafe { mem::transmute::<&'l mut vec::Vec0<N>, &'l mut [N, ..0]>(self).iter_mut() }
+        unsafe { mem::transmute::<&'l mut vec::Vec0<N>, &'l mut [N; 0]>(self).iter_mut() }
     }
 }
 

--- a/src/structs/vec_macros.rs
+++ b/src/structs/vec_macros.rs
@@ -20,7 +20,7 @@ macro_rules! as_array_impl(
         impl<N> $t<N> {
             /// View this vector as an array.
             #[inline]
-            pub fn as_array(&self) -> &[N, ..$dim] {
+            pub fn as_array(&self) -> &[N; $dim] {
                 unsafe {
                     mem::transmute(self)
                 }
@@ -28,7 +28,7 @@ macro_rules! as_array_impl(
 
             /// View this vector as a mutable array.
             #[inline]
-            pub fn as_array_mut(&mut self) -> &mut [N, ..$dim] {
+            pub fn as_array_mut(&mut self) -> &mut [N; $dim] {
                 unsafe {
                     mem::transmute(self)
                 }
@@ -37,11 +37,11 @@ macro_rules! as_array_impl(
             // FIXME: because of https://github.com/rust-lang/rust/issues/16418 we cannot do the
             // array-to-vec conversion by-value:
             //
-            // pub fn from_array(array: [N, ..$dim]) -> $t<N>
+            // pub fn from_array(array: [N; $dim]) -> $t<N>
 
             /// View an array as a vector.
             #[inline]
-            pub fn from_array_ref(array: &[N, ..$dim]) -> &$t<N> {
+            pub fn from_array_ref(array: &[N; $dim]) -> &$t<N> {
                 unsafe {
                     mem::transmute(array)
                 }
@@ -49,7 +49,7 @@ macro_rules! as_array_impl(
 
             /// View an array as a vector.
             #[inline]
-            pub fn from_array_mut(array: &mut [N, ..$dim]) -> &mut $t<N> {
+            pub fn from_array_mut(array: &mut [N; $dim]) -> &mut $t<N> {
                 unsafe {
                     mem::transmute(array)
                 }
@@ -203,32 +203,32 @@ macro_rules! indexable_impl(
             #[inline]
             fn at(&self, i: uint) -> N {
                 unsafe {
-                    mem::transmute::<&$t<N>, &[N, ..$dim]>(self)[i]
+                    mem::transmute::<&$t<N>, &[N; $dim]>(self)[i]
                 }
             }
 
             #[inline]
             fn set(&mut self, i: uint, val: N) {
                 unsafe {
-                    mem::transmute::<&mut $t<N>, &mut [N, ..$dim]>(self)[i] = val
+                    mem::transmute::<&mut $t<N>, &mut [N; $dim]>(self)[i] = val
                 }
             }
 
             #[inline]
             fn swap(&mut self, i1: uint, i2: uint) {
                 unsafe {
-                    mem::transmute::<&mut $t<N>, &mut [N, ..$dim]>(self).swap(i1, i2)
+                    mem::transmute::<&mut $t<N>, &mut [N; $dim]>(self).swap(i1, i2)
                 }
             }
 
             #[inline]
             unsafe fn unsafe_at(&self, i: uint) -> N {
-                (*mem::transmute::<&$t<N>, &[N, ..$dim]>(self).unsafe_get(i))
+                (*mem::transmute::<&$t<N>, &[N; $dim]>(self).unsafe_get(i))
             }
 
             #[inline]
             unsafe fn unsafe_set(&mut self, i: uint, val: N) {
-                (*mem::transmute::<&mut $t<N>, &mut [N, ..$dim]>(self).get_unchecked_mut(i)) = val
+                (*mem::transmute::<&mut $t<N>, &mut [N; $dim]>(self).get_unchecked_mut(i)) = val
             }
         }
     )
@@ -271,7 +271,7 @@ macro_rules! iterable_impl(
             #[inline]
             fn iter<'l>(&'l self) -> Iter<'l, N> {
                 unsafe {
-                    mem::transmute::<&'l $t<N>, &'l [N, ..$dim]>(self).iter()
+                    mem::transmute::<&'l $t<N>, &'l [N; $dim]>(self).iter()
                 }
             }
         }
@@ -284,7 +284,7 @@ macro_rules! iterable_mut_impl(
             #[inline]
             fn iter_mut<'l>(&'l mut self) -> IterMut<'l, N> {
                 unsafe {
-                    mem::transmute::<&'l mut $t<N>, &'l mut [N, ..$dim]>(self).iter_mut()
+                    mem::transmute::<&'l mut $t<N>, &'l mut [N; $dim]>(self).iter_mut()
                 }
             }
         }


### PR DESCRIPTION
The version is rustc 0.13.0-dev (cd614164e 2015-01-02 02:31:12 +0000).

The fixed array syntax was changed from [x, ..3] to [x; 3].