### PR TITLE
Update to the last rust-nightly.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,8 @@ Feel free to add your project to this list if you happen to use **nalgebra**!
 #![warn(missing_docs)]
 #![feature(macro_rules)]
 #![feature(globs)]
+#![feature(default_type_params)]
+#![feature(associated_types)]
 #![feature(old_orphan_check)]
 #![doc(html_root_url = "http://nalgebra.org/doc")]
 
@@ -578,7 +580,7 @@ pub fn inv_rotate<V, M: Rotate<V>>(m: &M, v: &V) -> V {
 
 /// Rotates a copy of `m` by `amount` using `center` as the pivot point.
 #[inline(always)]
-pub fn append_rotation_wrt_point<LV: Neg<LV> + Copy,
+pub fn append_rotation_wrt_point<LV: Neg<Output = LV> + Copy,
                                  AV,
                                  M: RotationWithTranslation<LV, AV>>(
                                  m:      &M,
@@ -589,7 +591,7 @@ pub fn append_rotation_wrt_point<LV: Neg<LV> + Copy,
 
 /// Rotates a copy of `m` by `amount` using `m.translation()` as the pivot point.
 #[inline(always)]
-pub fn append_rotation_wrt_center<LV: Neg<LV> + Copy,
+pub fn append_rotation_wrt_center<LV: Neg<Output = LV> + Copy,
                                   AV,
                                   M: RotationWithTranslation<LV, AV>>(
                                   m:      &M,
@@ -603,7 +605,7 @@ pub fn append_rotation_wrt_center<LV: Neg<LV> + Copy,
 
 /// Builds a rotation matrix from `r`.
 #[inline(always)]
-pub fn to_rot_mat<N, LV, AV, M: Mat<N, LV, LV> + Rotation<AV>, R: RotationMatrix<N, LV, AV, M>>(r: &R) -> M {
+pub fn to_rot_mat<N, LV, AV, R: RotationMatrix<N, LV, AV>>(r: &R) -> R::Output {
     r.to_rot_mat()
 }
 
@@ -702,7 +704,7 @@ pub fn det<M: Det<N>, N>(m: &M) -> N {
 
 /// Computes the cross product of two vectors.
 #[inline(always)]
-pub fn cross<LV: Cross<AV>, AV>(a: &LV, b: &LV) -> AV {
+pub fn cross<LV: Cross>(a: &LV, b: &LV) -> LV::Output {
     Cross::cross(a, b)
 }
 
@@ -909,7 +911,7 @@ pub fn dim<V: Dim>() -> uint {
 
 /// Gets the indexable range of an object.
 #[inline(always)]
-pub fn shape<V: Shape<I, N>, I, N>(v: &V) -> I {
+pub fn shape<V: Shape<I>, I, N>(v: &V) -> I {
     v.shape()
 }
 

--- a/src/linalg/decompositions.rs
+++ b/src/linalg/decompositions.rs
@@ -41,7 +41,8 @@ pub fn householder_matrix<N, V, M>(dim: uint, start: uint, vec: V) -> M
 pub fn qr<N, V, M>(m: &M) -> (M, M)
     where N: BaseFloat,
           V: Indexable<uint, N> + Norm<N>,
-          M: Copy + Eye + ColSlice<V> + Transpose + Indexable<(uint, uint), N> + Mul<M, M> {
+          M: Copy + Eye + ColSlice<V> + Transpose + Indexable<(uint, uint), N> +
+             Mul<M, Output = M> {
     let (rows, cols) = m.shape();
     assert!(rows >= cols);
     let mut q : M = Eye::new_identity(rows);
@@ -76,7 +77,8 @@ pub fn qr<N, V, M>(m: &M) -> (M, M)
 pub fn eigen_qr<N, V, VS, M>(m: &M, eps: &N, niter: uint) -> (M, V)
     where N:  BaseFloat,
           VS: Indexable<uint, N> + Norm<N>,
-          M:  Indexable<(uint, uint), N> + SquareMat<N, V> + Add<M, M> + Sub<M, M> + ColSlice<VS> +
+          M:  Indexable<(uint, uint), N> + SquareMat<N, V> + Add<M, Output = M> +
+              Sub<M, Output = M> + ColSlice<VS> +
               ApproxEq<N> + Copy {
     let mut eigenvectors: M = ::one::<M>();
     let mut eigenvalues = *m;

--- a/src/structs/dmat.rs
+++ b/src/structs/dmat.rs
@@ -255,14 +255,16 @@ impl<N: Copy> Indexable<(uint, uint), N> for DMat<N> {
 
 }
 
-impl<N> Shape<(uint, uint), N> for DMat<N> {
+impl<N> Shape<(uint, uint)> for DMat<N> {
     #[inline]
     fn shape(&self) -> (uint, uint) {
         (self.nrows, self.ncols)
     }
 }
 
-impl<N> Index<(uint, uint), N> for DMat<N> {
+impl<N> Index<(uint, uint)> for DMat<N> {
+    type Output = N;
+
     fn index(&self, &(i, j): &(uint, uint)) -> &N {
         assert!(i < self.nrows);
         assert!(j < self.ncols);
@@ -273,7 +275,9 @@ impl<N> Index<(uint, uint), N> for DMat<N> {
     }
 }
 
-impl<N> IndexMut<(uint, uint), N> for DMat<N> {
+impl<N> IndexMut<(uint, uint)> for DMat<N> {
+    type Output = N;
+
     fn index_mut(&mut self, &(i, j): &(uint, uint)) -> &mut N {
         assert!(i < self.nrows);
         assert!(j < self.ncols);
@@ -286,7 +290,9 @@ impl<N> IndexMut<(uint, uint), N> for DMat<N> {
     }
 }
 
-impl<N: Copy + Mul<N, N> + Add<N, N> + Zero> Mul<DMat<N>, DMat<N>> for DMat<N> {
+impl<N: Copy + Mul<N, Output = N> + Add<N, Output = N> + Zero> Mul<DMat<N>> for DMat<N> {
+    type Output = DMat<N>;
+
     fn mul(self, right: DMat<N>) -> DMat<N> {
         assert!(self.ncols == right.nrows);
 
@@ -311,7 +317,9 @@ impl<N: Copy + Mul<N, N> + Add<N, N> + Zero> Mul<DMat<N>, DMat<N>> for DMat<N> {
     }
 }
 
-impl<N: Copy + Add<N, N> + Mul<N, N> + Zero> Mul<DVec<N>, DVec<N>> for DMat<N> {
+impl<N: Copy + Add<N, Output = N> + Mul<N, Output = N> + Zero> Mul<DVec<N>> for DMat<N> {
+    type Output = DVec<N>;
+
     fn mul(self, right: DVec<N>) -> DVec<N> {
         assert!(self.ncols == right.at.len());
 
@@ -334,7 +342,9 @@ impl<N: Copy + Add<N, N> + Mul<N, N> + Zero> Mul<DVec<N>, DVec<N>> for DMat<N> {
 }
 
 
-impl<N: Copy + Add<N, N> + Mul<N, N> + Zero> Mul<DMat<N>, DVec<N>> for DVec<N> {
+impl<N: Copy + Add<N, Output = N> + Mul<N, Output = N> + Zero> Mul<DMat<N>> for DVec<N> {
+    type Output = DVec<N>;
+
     fn mul(self, right: DMat<N>) -> DVec<N> {
         assert!(right.nrows == self.at.len());
 
@@ -635,7 +645,9 @@ impl<N: Show + Copy> Show for DMat<N> {
     }
 }
 
-impl<N: Copy + Mul<N, N>> Mul<N, DMat<N>> for DMat<N> {
+impl<N: Copy + Mul<N, Output = N>> Mul<N> for DMat<N> {
+    type Output = DMat<N>;
+
     #[inline]
     fn mul(self, right: N) -> DMat<N> {
         let mut res = self;
@@ -648,7 +660,9 @@ impl<N: Copy + Mul<N, N>> Mul<N, DMat<N>> for DMat<N> {
     }
 }
 
-impl<N: Copy + Div<N, N>> Div<N, DMat<N>> for DMat<N> {
+impl<N: Copy + Div<N, Output = N>> Div<N> for DMat<N> {
+    type Output = DMat<N>;
+
     #[inline]
     fn div(self, right: N) -> DMat<N> {
         let mut res = self;
@@ -661,7 +675,9 @@ impl<N: Copy + Div<N, N>> Div<N, DMat<N>> for DMat<N> {
     }
 }
 
-impl<N: Copy + Add<N, N>> Add<N, DMat<N>> for DMat<N> {
+impl<N: Copy + Add<N, Output = N>> Add<N> for DMat<N> {
+    type Output = DMat<N>;
+
     #[inline]
     fn add(self, right: N) -> DMat<N> {
         let mut res = self;
@@ -674,7 +690,9 @@ impl<N: Copy + Add<N, N>> Add<N, DMat<N>> for DMat<N> {
     }
 }
 
-impl<N: Copy + Sub<N, N>> Sub<N, DMat<N>> for DMat<N> {
+impl<N: Copy + Sub<N, Output = N>> Sub<N> for DMat<N> {
+    type Output = DMat<N>;
+
     #[inline]
     fn sub(self, right: N) -> DMat<N> {
         let mut res = self;

--- a/src/structs/dvec.rs
+++ b/src/structs/dvec.rs
@@ -67,7 +67,7 @@ impl<N> DVec<N> {
 
 impl<N> FromIterator<N> for DVec<N> {
     #[inline]
-    fn from_iter<I: Iterator<N>>(mut param: I) -> DVec<N> {
+    fn from_iter<I: Iterator<Item = N>>(mut param: I) -> DVec<N> {
         let mut res = DVec { at: Vec::new() };
 
         for e in param {

--- a/src/structs/dvec_macros.rs
+++ b/src/structs/dvec_macros.rs
@@ -34,7 +34,7 @@ macro_rules! dvec_impl(
             }
         }
 
-        impl<N> Shape<uint, N> for $dvec<N> {
+        impl<N> Shape<uint> for $dvec<N> {
             #[inline]
             fn shape(&self) -> uint {
                 self.len()
@@ -77,13 +77,17 @@ macro_rules! dvec_impl(
 
         }
 
-        impl<N> Index<uint, N> for $dvec<N> {
+        impl<N> Index<uint> for $dvec<N> {
+            type Output = N;
+
             fn index(&self, i: &uint) -> &N {
                 &self.as_slice()[*i]
             }
         }
 
-        impl<N> IndexMut<uint, N> for $dvec<N> {
+        impl<N> IndexMut<uint> for $dvec<N> {
+            type Output = N;
+
             fn index_mut(&mut self, i: &uint) -> &mut N {
                 &mut self.as_mut_slice()[*i]
             }
@@ -122,7 +126,7 @@ macro_rules! dvec_impl(
             }
         }
 
-        impl<N: Copy + Add<N, N> + Mul<N, N>> Axpy<N> for $dvec<N> {
+        impl<N: Copy + Add<N, Output = N> + Mul<N, Output = N>> Axpy<N> for $dvec<N> {
             fn axpy(&mut self, a: &N, x: &$dvec<N>) {
                 assert!(self.len() == x.len());
 
@@ -190,7 +194,9 @@ macro_rules! dvec_impl(
             }
         }
 
-        impl<N: Copy + Mul<N, N> + Zero> Mul<$dvec<N>, $dvec<N>> for $dvec<N> {
+        impl<N: Copy + Mul<N, Output = N> + Zero> Mul<$dvec<N>> for $dvec<N> {
+            type Output = $dvec<N>;
+
             #[inline]
             fn mul(self, right: $dvec<N>) -> $dvec<N> {
                 assert!(self.len() == right.len());
@@ -205,7 +211,9 @@ macro_rules! dvec_impl(
             }
         }
 
-        impl<N: Copy + Div<N, N> + Zero> Div<$dvec<N>, $dvec<N>> for $dvec<N> {
+        impl<N: Copy + Div<N, Output = N> + Zero> Div<$dvec<N>> for $dvec<N> {
+            type Output = $dvec<N>;
+
             #[inline]
             fn div(self, right: $dvec<N>) -> $dvec<N> {
                 assert!(self.len() == right.len());
@@ -220,7 +228,9 @@ macro_rules! dvec_impl(
             }
         }
 
-        impl<N: Copy + Add<N, N> + Zero> Add<$dvec<N>, $dvec<N>> for $dvec<N> {
+        impl<N: Copy + Add<N, Output = N> + Zero> Add<$dvec<N>> for $dvec<N> {
+            type Output = $dvec<N>;
+
             #[inline]
             fn add(self, right: $dvec<N>) -> $dvec<N> {
                 assert!(self.len() == right.len());
@@ -235,7 +245,9 @@ macro_rules! dvec_impl(
             }
         }
 
-        impl<N: Copy + Sub<N, N> + Zero> Sub<$dvec<N>, $dvec<N>> for $dvec<N> {
+        impl<N: Copy + Sub<N, Output = N> + Zero> Sub<$dvec<N>> for $dvec<N> {
+            type Output = $dvec<N>;
+
             #[inline]
             fn sub(self, right: $dvec<N>) -> $dvec<N> {
                 assert!(self.len() == right.len());
@@ -250,7 +262,9 @@ macro_rules! dvec_impl(
             }
         }
 
-        impl<N: Neg<N> + Zero + Copy> Neg<$dvec<N>> for $dvec<N> {
+        impl<N: Neg<Output = N> + Zero + Copy> Neg for $dvec<N> {
+            type Output = $dvec<N>;
+
             #[inline]
             fn neg(self) -> $dvec<N> {
                 FromIterator::from_iter(self.as_slice().iter().map(|a| -*a))
@@ -318,7 +332,9 @@ macro_rules! dvec_impl(
             }
         }
 
-        impl<N: Copy + Mul<N, N> + Zero> Mul<N, $dvec<N>> for $dvec<N> {
+        impl<N: Copy + Mul<N, Output = N> + Zero> Mul<N> for $dvec<N> {
+            type Output = $dvec<N>;
+
             #[inline]
             fn mul(self, right: N) -> $dvec<N> {
                 let mut res = self;
@@ -331,7 +347,9 @@ macro_rules! dvec_impl(
             }
         }
 
-        impl<N: Copy + Div<N, N> + Zero> Div<N, $dvec<N>> for $dvec<N> {
+        impl<N: Copy + Div<N, Output = N> + Zero> Div<N> for $dvec<N> {
+            type Output = $dvec<N>;
+
             #[inline]
             fn div(self, right: N) -> $dvec<N> {
                 let mut res = self;
@@ -344,7 +362,9 @@ macro_rules! dvec_impl(
             }
         }
 
-        impl<N: Copy + Add<N, N> + Zero> Add<N, $dvec<N>> for $dvec<N> {
+        impl<N: Copy + Add<N, Output = N> + Zero> Add<N> for $dvec<N> {
+            type Output = $dvec<N>;
+
             #[inline]
             fn add(self, right: N) -> $dvec<N> {
                 let mut res = self;
@@ -357,7 +377,9 @@ macro_rules! dvec_impl(
             }
         }
 
-        impl<N: Copy + Sub<N, N> + Zero> Sub<N, $dvec<N>> for $dvec<N> {
+        impl<N: Copy + Sub<N, Output = N> + Zero> Sub<N> for $dvec<N> {
+            type Output = $dvec<N>;
+
             #[inline]
             fn sub(self, right: N) -> $dvec<N> {
                 let mut res = self;
@@ -477,7 +499,7 @@ macro_rules! small_dvec_from_impl (
 
         impl<N: Zero> FromIterator<N> for $dvec<N> {
             #[inline]
-            fn from_iter<I: Iterator<N>>(mut param: I) -> $dvec<N> {
+            fn from_iter<I: Iterator<Item = N>>(mut param: I) -> $dvec<N> {
                 let mut at: [N; $dim] = [ $( $zeros, )* ];
 
                 let mut dim = 0;

--- a/src/structs/iso_macros.rs
+++ b/src/structs/iso_macros.rs
@@ -27,7 +27,9 @@ macro_rules! iso_impl(
 macro_rules! rotation_matrix_impl(
     ($t: ident, $trot: ident, $tlv: ident, $tav: ident) => (
         impl<N: Cast<f64> + BaseFloat>
-        RotationMatrix<N, $tlv<N>, $tav<N>, $trot<N>> for $t<N> {
+        RotationMatrix<N, $tlv<N>, $tav<N>> for $t<N> {
+            type Output = $trot<N>;
+
             #[inline]
             fn to_rot_mat(&self) -> $trot<N> {
                 self.rotation
@@ -61,7 +63,9 @@ macro_rules! one_impl(
 
 macro_rules! iso_mul_iso_impl(
     ($t: ident) => (
-        impl<N: BaseFloat> Mul<$t<N>, $t<N>> for $t<N> {
+        impl<N: BaseFloat> Mul<$t<N>> for $t<N> {
+            type Output = $t<N>;
+
             #[inline]
             fn mul(self, right: $t<N>) -> $t<N> {
                 $t::new_with_rotmat(
@@ -74,7 +78,9 @@ macro_rules! iso_mul_iso_impl(
 
 macro_rules! iso_mul_pnt_impl(
     ($t: ident, $tv: ident) => (
-        impl<N: BaseNum> Mul<$tv<N>, $tv<N>> for $t<N> {
+        impl<N: BaseNum> Mul<$tv<N>> for $t<N> {
+            type Output = $tv<N>;
+
             #[inline]
             fn mul(self, right: $tv<N>) -> $tv<N> {
                 self.rotation * right + self.translation
@@ -85,7 +91,8 @@ macro_rules! iso_mul_pnt_impl(
 
 macro_rules! pnt_mul_iso_impl(
     ($t: ident, $tv: ident) => (
-        impl<N: BaseNum> Mul<$t<N>, $tv<N>> for $tv<N> {
+        impl<N: BaseNum> Mul<$t<N>> for $tv<N> {
+            type Output = $tv<N>;
             #[inline]
             fn mul(self, right: $t<N>) -> $tv<N> {
                 (self + right.translation) * right.rotation
@@ -137,7 +144,7 @@ macro_rules! translation_impl(
 
 macro_rules! translate_impl(
     ($t: ident, $tv: ident) => (
-        impl<N: Copy + Add<N, N> + Sub<N, N>> Translate<$tv<N>> for $t<N> {
+        impl<N: Copy + Add<N, Output = N> + Sub<N, Output = N>> Translate<$tv<N>> for $t<N> {
             #[inline]
             fn translate(&self, v: &$tv<N>) -> $tv<N> {
                 *v + self.translation

--- a/src/structs/mat_macros.rs
+++ b/src/structs/mat_macros.rs
@@ -88,7 +88,9 @@ macro_rules! mat_cast_impl(
 
 macro_rules! add_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
-        impl<N: Add<N, N>> Add<$t<N>, $t<N>> for $t<N> {
+        impl<N: Add<N, Output = N>> Add<$t<N>> for $t<N> {
+            type Output = $t<N>;
+
             #[inline]
             fn add(self, right: $t<N>) -> $t<N> {
                 $t::new(self.$comp0 + right.$comp0 $(, self.$compN + right.$compN)*)
@@ -99,7 +101,9 @@ macro_rules! add_impl(
 
 macro_rules! sub_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
-        impl<N: Sub<N, N>> Sub<$t<N>, $t<N>> for $t<N> {
+        impl<N: Sub<N, Output = N>> Sub<$t<N>> for $t<N> {
+            type Output = $t<N>;
+
             #[inline]
             fn sub(self, right: $t<N>) -> $t<N> {
                 $t::new(self.$comp0 - right.$comp0 $(, self.$compN - right.$compN)*)
@@ -110,7 +114,9 @@ macro_rules! sub_impl(
 
 macro_rules! mat_mul_scalar_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
-        impl<N: Mul<N, N>> Mul<N, $t<N>> for N {
+        impl<N: Mul<N, Output = N>> Mul<N> for N {
+            type Output = $t<N>;
+
             #[inline]
             fn mul(self, right: N) -> $t<N> {
                 $t::new(self.$comp0 * *right $(, self.$compN * *right)*)
@@ -121,7 +127,9 @@ macro_rules! mat_mul_scalar_impl(
 
 macro_rules! mat_div_scalar_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
-        impl<N: Div<N, N>> Div<N, $t<N>> for $t<N> {
+        impl<N: Div<N, Output = N>> Div<N> for $t<N> {
+            type Output = $t<N>;
+
             #[inline]
             fn div(self, right: N) -> $t<N> {
                 $t::new(self.$comp0 / *right $(, self.$compN / *right)*)
@@ -132,7 +140,9 @@ macro_rules! mat_div_scalar_impl(
 
 macro_rules! mat_add_scalar_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
-        impl<N: Add<N, N>> Add<N, $t<N>> for $t<N> {
+        impl<N: Add<N, Output = N>> Add<N> for $t<N> {
+            type Output = $t<N>;
+
             #[inline]
             fn add(self, right: N) -> $t<N> {
                 $t::new(self.$comp0 + *right $(, self.$compN + *right)*)
@@ -157,7 +167,9 @@ macro_rules! eye_impl(
 
 macro_rules! mat_sub_scalar_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
-        impl<N: Sub<N, N> Sub<N, $t<N>> for $t<N> {
+        impl<N: Sub<N, Output = N> Sub<N> for $t<N> {
+            type Output = $t<N>;
+
             #[inline]
             fn sub(self, right: &N) -> $t<N> {
                 $t::new(self.$comp0 - *right $(, self.$compN - *right)*)
@@ -246,7 +258,7 @@ macro_rules! dim_impl(
 
 macro_rules! indexable_impl(
   ($t: ident, $dim: expr) => (
-    impl<N> Shape<(uint, uint), N> for $t<N> {
+    impl<N> Shape<(uint, uint)> for $t<N> {
         #[inline]
         fn shape(&self) -> (uint, uint) {
             ($dim, $dim)
@@ -291,7 +303,9 @@ macro_rules! indexable_impl(
 
 macro_rules! index_impl(
     ($t: ident, $dim: expr) => (
-        impl<N> Index<(uint, uint), N> for $t<N> {
+        impl<N> Index<(uint, uint)> for $t<N> {
+            type Output = N;
+
             fn index(&self, &(i, j): &(uint, uint)) -> &N {
                 unsafe {
                     &mem::transmute::<&$t<N>, &mut [N; $dim * $dim]>(self)[i + j * $dim]
@@ -299,7 +313,9 @@ macro_rules! index_impl(
             }
         }
 
-        impl<N> IndexMut<(uint, uint), N> for $t<N> {
+        impl<N> IndexMut<(uint, uint)> for $t<N> {
+            type Output = N;
+
             fn index_mut(&mut self, &(i, j): &(uint, uint)) -> &mut N {
                 unsafe {
                     &mut mem::transmute::<&mut $t<N>, &mut [N; $dim * $dim]>(self)[i + j * $dim]
@@ -426,7 +442,8 @@ macro_rules! diag_impl(
 
 macro_rules! mat_mul_mat_impl(
   ($t: ident, $dim: expr) => (
-    impl<N: Copy + BaseNum> Mul<$t<N>, $t<N>> for $t<N> {
+    impl<N: Copy + BaseNum> Mul<$t<N>> for $t<N> {
+        type Output = $t<N>;
         #[inline]
         fn mul(self, right: $t<N>) -> $t<N> {
             // careful! we need to comute other * self here (self is the rhs).
@@ -454,7 +471,9 @@ macro_rules! mat_mul_mat_impl(
 
 macro_rules! vec_mul_mat_impl(
   ($t: ident, $v: ident, $dim: expr, $zero: expr) => (
-    impl<N: Copy + BaseNum> Mul<$t<N>, $v<N>> for $v<N> {
+    impl<N: Copy + BaseNum> Mul<$t<N>> for $v<N> {
+        type Output = $v<N>;
+
         #[inline]
         fn mul(self, right: $t<N>) -> $v<N> {
             let mut res : $v<N> = $zero();
@@ -476,7 +495,9 @@ macro_rules! vec_mul_mat_impl(
 
 macro_rules! mat_mul_vec_impl(
   ($t: ident, $v: ident, $dim: expr, $zero: expr) => (
-    impl<N: Copy + BaseNum> Mul<$v<N>, $v<N>> for $t<N> {
+    impl<N: Copy + BaseNum> Mul<$v<N>> for $t<N> {
+        type Output = $v<N>;
+
         #[inline]
         fn mul(self, right: $v<N>) -> $v<N> {
             let mut res : $v<N> = $zero();
@@ -685,7 +706,7 @@ macro_rules! from_homogeneous_impl(
 
 macro_rules! outer_impl(
     ($t: ident, $m: ident) => (
-        impl<N: Copy + Mul<N, N> + Zero> Outer<$m<N>> for $t<N> {
+        impl<N: Copy + Mul<N, Output = N> + Zero> Outer<$m<N>> for $t<N> {
             #[inline]
             fn outer(&self, other: &$t<N>) -> $m<N> {
                 let mut res: $m<N> = ::zero();

--- a/src/structs/pnt_macros.rs
+++ b/src/structs/pnt_macros.rs
@@ -21,7 +21,9 @@ macro_rules! orig_impl(
 
 macro_rules! pnt_sub_impl(
     ($t: ident, $tv: ident) => (
-        impl<N: Copy + Sub<N, N>> Sub<$t<N>, $tv<N>> for $t<N> {
+        impl<N: Copy + Sub<N, Output = N>> Sub<$t<N>> for $t<N> {
+            type Output = $tv<N>;
+
             #[inline]
             fn sub(self, right: $t<N>) -> $tv<N> {
                 *self.as_vec() - *right.as_vec()
@@ -32,7 +34,9 @@ macro_rules! pnt_sub_impl(
 
 macro_rules! pnt_add_vec_impl(
     ($t: ident, $tv: ident, $comp0: ident $(,$compN: ident)*) => (
-        impl<N: Copy + Add<N, N>> Add<$tv<N>, $t<N>> for $t<N> {
+        impl<N: Copy + Add<N, Output = N>> Add<$tv<N>> for $t<N> {
+            type Output = $t<N>;
+
             #[inline]
             fn add(self, right: $tv<N>) -> $t<N> {
                 $t::new(self.$comp0 + right.$comp0 $(, self.$compN + right.$compN)*)
@@ -43,7 +47,9 @@ macro_rules! pnt_add_vec_impl(
 
 macro_rules! pnt_sub_vec_impl(
     ($t: ident, $tv: ident, $comp0: ident $(,$compN: ident)*) => (
-        impl<N: Copy + Sub<N, N>> Sub<$tv<N>, $t<N>> for $t<N> {
+        impl<N: Copy + Sub<N, Output = N>> Sub<$tv<N>> for $t<N> {
+            type Output = $t<N>;
+
             #[inline]
             fn sub(self, right: $tv<N>) -> $t<N> {
                 $t::new(self.$comp0 - right.$comp0 $(, self.$compN - right.$compN)*)
@@ -116,7 +122,7 @@ macro_rules! pnt_to_homogeneous_impl(
 
 macro_rules! pnt_from_homogeneous_impl(
     ($t: ident, $t2: ident, $extra: ident, $comp0: ident $(,$compN: ident)*) => (
-        impl<N: Copy + Div<N, N> + One + Zero> FromHomogeneous<$t2<N>> for $t<N> {
+        impl<N: Copy + Div<N, Output = N> + One + Zero> FromHomogeneous<$t2<N>> for $t<N> {
             fn from(v: &$t2<N>) -> $t<N> {
                 let mut res: $t<N> = Orig::orig();
 

--- a/src/structs/quat.rs
+++ b/src/structs/quat.rs
@@ -56,7 +56,7 @@ impl<N> Quat<N> {
     }
 }
 
-impl<N: Neg<N> + Copy> Quat<N> {
+impl<N: Neg<Output = N> + Copy> Quat<N> {
     /// Replaces this quaternion by its conjugate.
     #[inline]
     pub fn conjugate(&mut self) {
@@ -123,7 +123,10 @@ impl<N: BaseFloat> Norm<N> for Quat<N> {
     }
 }
 
-impl<N: Copy + Mul<N, N> + Sub<N, N> + Add<N, N>> Mul<Quat<N>, Quat<N>> for Quat<N> {
+impl<N> Mul<Quat<N>> for Quat<N>
+    where N: Copy + Mul<N, Output = N> + Sub<N, Output = N> + Add<N, Output = N> {
+    type Output = Quat<N>;
+
     #[inline]
     fn mul(self, right: Quat<N>) -> Quat<N> {
         Quat::new(
@@ -134,7 +137,9 @@ impl<N: Copy + Mul<N, N> + Sub<N, N> + Add<N, N>> Mul<Quat<N>, Quat<N>> for Quat
     }
 }
 
-impl<N: ApproxEq<N> + BaseFloat> Div<Quat<N>, Quat<N>> for Quat<N> {
+impl<N: ApproxEq<N> + BaseFloat> Div<Quat<N>> for Quat<N> {
+    type Output = Quat<N>;
+
     #[inline]
     fn div(self, right: Quat<N>) -> Quat<N> {
         self * right.inv_cpy().expect("Unable to invert the denominator.")
@@ -261,7 +266,7 @@ impl<N: BaseNum> One for UnitQuat<N> {
     }
 }
 
-impl<N: Copy + Neg<N>> Inv for UnitQuat<N> {
+impl<N: Copy + Neg<Output = N>> Inv for UnitQuat<N> {
     #[inline]
     fn inv_cpy(&self) -> Option<UnitQuat<N>> {
         let mut cpy = *self;
@@ -307,21 +312,27 @@ impl<N: ApproxEq<N>> ApproxEq<N> for UnitQuat<N> {
     }
 }
 
-impl<N: BaseFloat + ApproxEq<N>> Div<UnitQuat<N>, UnitQuat<N>> for UnitQuat<N> {
+impl<N: BaseFloat + ApproxEq<N>> Div<UnitQuat<N>> for UnitQuat<N> {
+    type Output = UnitQuat<N>;
+
     #[inline]
     fn div(self, other: UnitQuat<N>) -> UnitQuat<N> {
         UnitQuat { q: self.q / other.q }
     }
 }
 
-impl<N: BaseNum> Mul<UnitQuat<N>, UnitQuat<N>> for UnitQuat<N> {
+impl<N: BaseNum> Mul<UnitQuat<N>> for UnitQuat<N> {
+    type Output = UnitQuat<N>;
+
     #[inline]
     fn mul(self, right: UnitQuat<N>) -> UnitQuat<N> {
         UnitQuat { q: self.q * right.q }
     }
 }
 
-impl<N: BaseNum> Mul<Vec3<N>, Vec3<N>> for UnitQuat<N> {
+impl<N: BaseNum> Mul<Vec3<N>> for UnitQuat<N> {
+    type Output = Vec3<N>;
+
     #[inline]
     fn mul(self, right: Vec3<N>) -> Vec3<N> {
         let _2: N = ::one::<N>() + ::one();
@@ -334,14 +345,18 @@ impl<N: BaseNum> Mul<Vec3<N>, Vec3<N>> for UnitQuat<N> {
     }
 }
 
-impl<N: BaseNum> Mul<Pnt3<N>, Pnt3<N>> for UnitQuat<N> {
+impl<N: BaseNum> Mul<Pnt3<N>> for UnitQuat<N> {
+    type Output = Pnt3<N>;
+
     #[inline]
     fn mul(self, right: Pnt3<N>) -> Pnt3<N> {
         ::orig::<Pnt3<N>>() + self * *right.as_vec()
     }
 }
 
-impl<N: BaseNum> Mul<UnitQuat<N>, Vec3<N>> for Vec3<N> {
+impl<N: BaseNum> Mul<UnitQuat<N>> for Vec3<N> {
+    type Output = Vec3<N>;
+
     #[inline]
     fn mul(self, right: UnitQuat<N>) -> Vec3<N> {
         let mut inv_quat = right;
@@ -352,7 +367,9 @@ impl<N: BaseNum> Mul<UnitQuat<N>, Vec3<N>> for Vec3<N> {
     }
 }
 
-impl<N: BaseNum> Mul<UnitQuat<N>, Pnt3<N>> for Pnt3<N> {
+impl<N: BaseNum> Mul<UnitQuat<N>> for Pnt3<N> {
+    type Output = Pnt3<N>;
+
     #[inline]
     fn mul(self, right: UnitQuat<N>) -> Pnt3<N> {
         ::orig::<Pnt3<N>>() + *self.as_vec() * right

--- a/src/structs/rot.rs
+++ b/src/structs/rot.rs
@@ -19,7 +19,7 @@ pub struct Rot2<N> {
     submat: Mat2<N>
 }
 
-impl<N: Clone + BaseFloat + Neg<N> + Copy> Rot2<N> {
+impl<N: Clone + BaseFloat + Neg<Output = N> + Copy> Rot2<N> {
     /// Builds a 2 dimensional rotation matrix from an angle in radian.
     pub fn new(angle: Vec1<N>) -> Rot2<N> {
         let (sia, coa) = angle.x.sin_cos();
@@ -67,7 +67,7 @@ impl<N: BaseFloat + Clone> Rotation<Vec1<N>> for Rot2<N> {
     }
 }
 
-impl<N: Clone + Rand + BaseFloat + Neg<N> + Copy> Rand for Rot2<N> {
+impl<N: Rand + BaseFloat> Rand for Rot2<N> {
     #[inline]
     fn rand<R: Rng>(rng: &mut R) -> Rot2<N> {
         Rot2::new(rng.gen())

--- a/src/structs/rot_macros.rs
+++ b/src/structs/rot_macros.rs
@@ -80,7 +80,9 @@ macro_rules! dim_impl(
 
 macro_rules! rotation_matrix_impl(
     ($t: ident, $tlv: ident, $tav: ident) => (
-        impl<N: Zero + BaseNum + Cast<f64> + BaseFloat> RotationMatrix<N, $tlv<N>, $tav<N>, $t<N>> for $t<N> {
+        impl<N: Zero + BaseNum + Cast<f64> + BaseFloat> RotationMatrix<N, $tlv<N>, $tav<N>> for $t<N> {
+            type Output = $t<N>;
+
             #[inline]
             fn to_rot_mat(&self) -> $t<N> {
                 self.clone()
@@ -102,7 +104,9 @@ macro_rules! one_impl(
 
 macro_rules! rot_mul_rot_impl(
     ($t: ident) => (
-        impl<N: BaseNum> Mul<$t<N>, $t<N>> for $t<N> {
+        impl<N: BaseNum> Mul<$t<N>> for $t<N> {
+            type Output = $t<N>;
+
             #[inline]
             fn mul(self, right: $t<N>) -> $t<N> {
                 $t { submat: self.submat * right.submat }
@@ -113,7 +117,9 @@ macro_rules! rot_mul_rot_impl(
 
 macro_rules! rot_mul_vec_impl(
     ($t: ident, $tv: ident) => (
-        impl<N: BaseNum> Mul<$tv<N>, $tv<N>> for $t<N> {
+        impl<N: BaseNum> Mul<$tv<N>> for $t<N> {
+            type Output = $tv<N>;
+
             #[inline]
             fn mul(self, right: $tv<N>) -> $tv<N> {
                 self.submat * right
@@ -130,7 +136,9 @@ macro_rules! rot_mul_pnt_impl(
 
 macro_rules! vec_mul_rot_impl(
     ($t: ident, $tv: ident) => (
-        impl<N: BaseNum> Mul<$t<N>, $tv<N>> for $tv<N> {
+        impl<N: BaseNum> Mul<$t<N>> for $tv<N> {
+            type Output = $tv<N>;
+
             #[inline]
             fn mul(self, right: $t<N>) -> $tv<N> {
                 self * right.submat
@@ -223,7 +231,9 @@ macro_rules! col_impl(
 
 macro_rules! index_impl(
     ($t: ident) => (
-        impl<N> Index<(uint, uint), N> for $t<N> {
+        impl<N> Index<(uint, uint)> for $t<N> {
+            type Output = N;
+
             fn index(&self, i: &(uint, uint)) -> &N {
                 &self.submat[*i]
             }

--- a/src/structs/spec/identity.rs
+++ b/src/structs/spec/identity.rs
@@ -22,7 +22,9 @@ impl Inv for mat::Identity {
     }
 }
 
-impl<T: Clone> Mul<T, T> for mat::Identity {
+impl<T: Clone> Mul<T> for mat::Identity {
+    type Output = T;
+
     #[inline]
     fn mul(self, other: T) -> T {
         other

--- a/src/structs/spec/mat.rs
+++ b/src/structs/spec/mat.rs
@@ -210,7 +210,9 @@ impl<N: Copy> Col<Vec3<N>> for Mat3<N> {
     }
 }
 
-impl<N: Copy + Mul<N, N> + Add<N, N>> Mul<Mat3<N>, Mat3<N>> for Mat3<N> {
+impl<N: Copy + Mul<N, Output = N> + Add<N, Output = N>> Mul<Mat3<N>> for Mat3<N> {
+    type Output = Mat3<N>;
+
     #[inline]
     fn mul(self, right: Mat3<N>) -> Mat3<N> {
         Mat3::new(
@@ -229,7 +231,9 @@ impl<N: Copy + Mul<N, N> + Add<N, N>> Mul<Mat3<N>, Mat3<N>> for Mat3<N> {
     }
 }
 
-impl<N: Copy + Mul<N, N> + Add<N, N>> Mul<Mat2<N>, Mat2<N>> for Mat2<N> {
+impl<N: Copy + Mul<N, Output = N> + Add<N, Output = N>> Mul<Mat2<N>> for Mat2<N> {
+    type Output = Mat2<N>;
+
     #[inline(always)]
     fn mul(self, right: Mat2<N>) -> Mat2<N> {
         Mat2::new(
@@ -242,7 +246,9 @@ impl<N: Copy + Mul<N, N> + Add<N, N>> Mul<Mat2<N>, Mat2<N>> for Mat2<N> {
     }
 }
 
-impl<N: Copy + Mul<N, N> + Add<N, N>> Mul<Vec3<N>, Vec3<N>> for Mat3<N> {
+impl<N: Copy + Mul<N, Output = N> + Add<N, Output = N>> Mul<Vec3<N>> for Mat3<N> {
+    type Output = Vec3<N>;
+
     #[inline(always)]
     fn mul(self, right: Vec3<N>) -> Vec3<N> {
         Vec3::new(
@@ -253,7 +259,9 @@ impl<N: Copy + Mul<N, N> + Add<N, N>> Mul<Vec3<N>, Vec3<N>> for Mat3<N> {
     }
 }
 
-impl<N: Copy + Mul<N, N> + Add<N, N>> Mul<Mat3<N>, Vec3<N>> for Vec3<N> {
+impl<N: Copy + Mul<N, Output = N> + Add<N, Output = N>> Mul<Mat3<N>> for Vec3<N> {
+    type Output = Vec3<N>;
+
     #[inline(always)]
     fn mul(self, right: Mat3<N>) -> Vec3<N> {
         Vec3::new(
@@ -264,7 +272,9 @@ impl<N: Copy + Mul<N, N> + Add<N, N>> Mul<Mat3<N>, Vec3<N>> for Vec3<N> {
     }
 }
 
-impl<N: Copy + Mul<N, N> + Add<N, N>> Mul<Mat2<N>, Vec2<N>> for Vec2<N> {
+impl<N: Copy + Mul<N, Output = N> + Add<N, Output = N>> Mul<Mat2<N>> for Vec2<N> {
+    type Output = Vec2<N>;
+
     #[inline(always)]
     fn mul(self, right: Mat2<N>) -> Vec2<N> {
         Vec2::new(
@@ -274,7 +284,9 @@ impl<N: Copy + Mul<N, N> + Add<N, N>> Mul<Mat2<N>, Vec2<N>> for Vec2<N> {
     }
 }
 
-impl<N: Copy + Mul<N, N> + Add<N, N>> Mul<Vec2<N>, Vec2<N>> for Mat2<N> {
+impl<N: Copy + Mul<N, Output = N> + Add<N, Output = N>> Mul<Vec2<N>> for Mat2<N> {
+    type Output = Vec2<N>;
+
     #[inline(always)]
     fn mul(self, right: Vec2<N>) -> Vec2<N> {
         Vec2::new(
@@ -284,7 +296,9 @@ impl<N: Copy + Mul<N, N> + Add<N, N>> Mul<Vec2<N>, Vec2<N>> for Mat2<N> {
     }
 }
 
-impl<N: Copy + Mul<N, N> + Add<N, N>> Mul<Pnt3<N>, Pnt3<N>> for Mat3<N> {
+impl<N: Copy + Mul<N, Output = N> + Add<N, Output = N>> Mul<Pnt3<N>> for Mat3<N> {
+    type Output = Pnt3<N>;
+
     #[inline(always)]
     fn mul(self, right: Pnt3<N>) -> Pnt3<N> {
         Pnt3::new(
@@ -295,7 +309,9 @@ impl<N: Copy + Mul<N, N> + Add<N, N>> Mul<Pnt3<N>, Pnt3<N>> for Mat3<N> {
     }
 }
 
-impl<N: Copy + Mul<N, N> + Add<N, N>> Mul<Mat3<N>, Pnt3<N>> for Pnt3<N> {
+impl<N: Copy + Mul<N, Output = N> + Add<N, Output = N>> Mul<Mat3<N>> for Pnt3<N> {
+    type Output = Pnt3<N>;
+
     #[inline(always)]
     fn mul(self, right: Mat3<N>) -> Pnt3<N> {
         Pnt3::new(
@@ -306,7 +322,9 @@ impl<N: Copy + Mul<N, N> + Add<N, N>> Mul<Mat3<N>, Pnt3<N>> for Pnt3<N> {
     }
 }
 
-impl<N: Copy + Mul<N, N> + Add<N, N>> Mul<Mat2<N>, Pnt2<N>> for Pnt2<N> {
+impl<N: Copy + Mul<N, Output = N> + Add<N, Output = N>> Mul<Mat2<N>> for Pnt2<N> {
+    type Output = Pnt2<N>;
+
     #[inline(always)]
     fn mul(self, right: Mat2<N>) -> Pnt2<N> {
         Pnt2::new(
@@ -316,7 +334,9 @@ impl<N: Copy + Mul<N, N> + Add<N, N>> Mul<Mat2<N>, Pnt2<N>> for Pnt2<N> {
     }
 }
 
-impl<N: Copy + Mul<N, N> + Add<N, N>> Mul<Pnt2<N>, Pnt2<N>> for Mat2<N> {
+impl<N: Copy + Mul<N, Output = N> + Add<N, Output = N>> Mul<Pnt2<N>> for Mat2<N> {
+    type Output = Pnt2<N>;
+
     #[inline(always)]
     fn mul(self, right: Pnt2<N>) -> Pnt2<N> {
         Pnt2::new(

--- a/src/structs/spec/vec.rs
+++ b/src/structs/spec/vec.rs
@@ -4,7 +4,9 @@ use traits::geometry::{Norm, Cross, CrossMatrix, UniformSphereSample};
 use structs::vec::{Vec1, Vec2, Vec3, Vec4};
 use structs::mat::Mat3;
 
-impl<N: Copy + Mul<N, N> + Sub<N, N>> Cross<Vec1<N>> for Vec2<N> {
+impl<N: Copy + Mul<N, Output = N> + Sub<N, Output = N>> Cross for Vec2<N> {
+    type Output = Vec1<N>;
+
     #[inline]
     fn cross(&self, other: &Vec2<N>) -> Vec1<N> {
         Vec1::new(self.x * other.y - self.y * other.x)
@@ -12,14 +14,16 @@ impl<N: Copy + Mul<N, N> + Sub<N, N>> Cross<Vec1<N>> for Vec2<N> {
 }
 
 // FIXME: instead of returning a Vec2, define a Mat2x1 matrix?
-impl<N: Neg<N> + Copy> CrossMatrix<Vec2<N>> for Vec2<N> {
+impl<N: Neg<Output = N> + Copy> CrossMatrix<Vec2<N>> for Vec2<N> {
     #[inline]
     fn cross_matrix(&self) -> Vec2<N> {
         Vec2::new(-self.y, self.x)
     }
 }
 
-impl<N: Copy + Mul<N, N> + Sub<N, N>> Cross<Vec3<N>> for Vec3<N> {
+impl<N: Copy + Mul<N, Output = N> + Sub<N, Output = N>> Cross for Vec3<N> {
+    type Output = Vec3<N>;
+
     #[inline]
     fn cross(&self, other: &Vec3<N>) -> Vec3<N> {
         Vec3::new(
@@ -30,7 +34,7 @@ impl<N: Copy + Mul<N, N> + Sub<N, N>> Cross<Vec3<N>> for Vec3<N> {
     }
 }
 
-impl<N: Neg<N> + Zero + Copy> CrossMatrix<Mat3<N>> for Vec3<N> {
+impl<N: Neg<Output = N> + Zero + Copy> CrossMatrix<Mat3<N>> for Vec3<N> {
     #[inline]
     fn cross_matrix(&self) -> Mat3<N> {
         Mat3::new(
@@ -88,7 +92,7 @@ impl<N: One> Basis for Vec1<N> {
     }
 }
 
-impl<N: Copy + One + Zero + Neg<N>> Basis for Vec2<N> {
+impl<N: Copy + One + Zero + Neg<Output = N>> Basis for Vec2<N> {
     #[inline(always)]
     fn canonical_basis(f: |Vec2<N>| -> bool) {
         if !f(Vec2::new(::one(), ::zero())) { return };

--- a/src/structs/spec/vec0.rs
+++ b/src/structs/spec/vec0.rs
@@ -20,21 +20,25 @@ impl<N> Zero for vec::Vec0<N> {
     }
 }
 
-impl<N> Index<uint, N> for vec::Vec0<N> {
+impl<N> Index<uint> for vec::Vec0<N> {
+    type Output = N;
+
     #[inline]
     fn index(&self, _: &uint) -> &N {
         panic!("Canot index a Vec0.")
     }
 }
 
-impl<N> IndexMut<uint, N> for vec::Vec0<N> {
+impl<N> IndexMut<uint> for vec::Vec0<N> {
+    type Output = N;
+
     #[inline]
     fn index_mut(&mut self, _: &uint) -> &mut N {
         panic!("Canot index a Vec0.")
     }
 }
 
-impl<N> Shape<uint, N> for vec::Vec0<N> {
+impl<N> Shape<uint> for vec::Vec0<N> {
     #[inline]
     fn shape(&self) -> uint {
         0
@@ -99,21 +103,27 @@ impl<N> Basis for vec::Vec0<N> {
     }
 }
 
-impl<N, T> Add<T, vec::Vec0<N>> for vec::Vec0<N> {
+impl<N, T> Add<T> for vec::Vec0<N> {
+    type Output = vec::Vec0<N>;
+
     #[inline]
     fn add(self, _: T) -> vec::Vec0<N> {
         vec::Vec0
     }
 }
 
-impl<N, T> Sub<T, vec::Vec0<N>> for vec::Vec0<N> {
+impl<N, T> Sub<T> for vec::Vec0<N> {
+    type Output = vec::Vec0<N>;
+
     #[inline]
     fn sub(self, _: T) -> vec::Vec0<N> {
         vec::Vec0
     }
 }
 
-impl<N: Neg<N> + Copy> Neg<vec::Vec0<N>> for vec::Vec0<N> {
+impl<N: Neg<Output = N> + Copy> Neg for vec::Vec0<N> {
+    type Output = vec::Vec0<N>;
+
     #[inline]
     fn neg(self) -> vec::Vec0<N> {
         vec::Vec0
@@ -127,21 +137,25 @@ impl<N: BaseNum> Dot<N> for vec::Vec0<N> {
     }
 }
 
-impl<N, T> Mul<T, vec::Vec0<N>> for vec::Vec0<N> {
+impl<N, T> Mul<T> for vec::Vec0<N> {
+    type Output = vec::Vec0<N>;
+
     #[inline]
     fn mul(self, _: T) -> vec::Vec0<N> {
         vec::Vec0
     }
 }
 
-impl<N, T> Div<T, vec::Vec0<N>> for vec::Vec0<N> {
+impl<N, T> Div<T> for vec::Vec0<N> {
+    type Output = vec::Vec0<N>;
+
     #[inline]
     fn div(self, _: T) -> vec::Vec0<N> {
         vec::Vec0
     }
 }
 
-impl<N: Copy + Add<N, N> + Neg<N>> Translation<vec::Vec0<N>> for vec::Vec0<N> {
+impl<N: Copy + Add<N, Output = N> + Neg<Output = N>> Translation<vec::Vec0<N>> for vec::Vec0<N> {
     #[inline]
     fn translation(&self) -> vec::Vec0<N> {
         *self
@@ -229,7 +243,7 @@ impl<N: One> One for vec::Vec0<N> {
 
 impl<N> FromIterator<N> for vec::Vec0<N> {
     #[inline]
-    fn from_iter<I: Iterator<N>>(_: I) -> vec::Vec0<N> {
+    fn from_iter<I: Iterator<Item = N>>(_: I) -> vec::Vec0<N> {
         vec::Vec0
     }
 }

--- a/src/structs/vec_macros.rs
+++ b/src/structs/vec_macros.rs
@@ -192,7 +192,7 @@ macro_rules! vec_cast_impl(
 
 macro_rules! indexable_impl(
     ($t: ident, $dim: expr) => (
-        impl<N> Shape<uint, N> for $t<N> {
+        impl<N> Shape<uint> for $t<N> {
             #[inline]
             fn shape(&self) -> uint {
                 $dim
@@ -236,13 +236,17 @@ macro_rules! indexable_impl(
 
 macro_rules! index_impl(
     ($t: ident) => (
-        impl<N> Index<uint, N> for $t<N> {
+        impl<N> Index<uint> for $t<N> {
+            type Output = N;
+
             fn index(&self, i: &uint) -> &N {
                 &self.as_array()[*i]
             }
         }
 
-        impl<N> IndexMut<uint, N> for $t<N> {
+        impl<N> IndexMut<uint> for $t<N> {
+            type Output = N;
+
             fn index_mut(&mut self, i: &uint) -> &mut N {
                 &mut self.as_array_mut()[*i]
             }
@@ -391,7 +395,9 @@ macro_rules! axpy_impl(
 
 macro_rules! add_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
-        impl<N: Add<N, N>> Add<$t<N>, $t<N>> for $t<N> {
+        impl<N: Add<N, Output = N>> Add<$t<N>> for $t<N> {
+            type Output = $t<N>;
+
             #[inline]
             fn add(self, right: $t<N>) -> $t<N> {
                 $t::new(self.$comp0 + right.$comp0 $(, self.$compN + right.$compN)*)
@@ -403,7 +409,9 @@ macro_rules! add_impl(
 macro_rules! scalar_add_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
         // $t against scalar
-        impl<N: Copy + Add<N, N>> Add<N, $t<N>> for $t<N> {
+        impl<N: Copy + Add<N, Output = N>> Add<N> for $t<N> {
+            type Output = $t<N>;
+
             #[inline]
             fn add(self, right: N) -> $t<N> {
                 $t::new(self.$comp0 + right $(, self.$compN + right)*)
@@ -414,7 +422,9 @@ macro_rules! scalar_add_impl(
 
 macro_rules! sub_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
-        impl<N: Sub<N, N>> Sub<$t<N>, $t<N>> for $t<N> {
+        impl<N: Sub<N, Output = N>> Sub<$t<N>> for $t<N> {
+            type Output = $t<N>;
+
             #[inline]
             fn sub(self, right: $t<N>) -> $t<N> {
                 $t::new(self.$comp0 - right.$comp0 $(, self.$compN - right.$compN)*)
@@ -425,7 +435,9 @@ macro_rules! sub_impl(
 
 macro_rules! scalar_sub_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
-        impl<N: Copy + Sub<N, N>> Sub<N, $t<N>> for $t<N> {
+        impl<N: Copy + Sub<N, Output = N>> Sub<N> for $t<N> {
+            type Output = $t<N>;
+
             #[inline]
             fn sub(self, right: N) -> $t<N> {
                 $t::new(self.$comp0 - right $(, self.$compN - right)*)
@@ -436,7 +448,8 @@ macro_rules! scalar_sub_impl(
 
 macro_rules! mul_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
-        impl<N: Copy + Mul<N, N>> Mul<$t<N>, $t<N>> for $t<N> {
+        impl<N: Copy + Mul<N, Output = N>> Mul<$t<N>> for $t<N> {
+            type Output = $t<N>;
             #[inline]
             fn mul(self, right: $t<N>) -> $t<N> {
                 $t::new(self.$comp0 * right.$comp0 $(, self.$compN * right.$compN)*)
@@ -447,7 +460,9 @@ macro_rules! mul_impl(
 
 macro_rules! scalar_mul_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
-        impl<N: Copy + Mul<N, N>> Mul<N, $t<N>> for $t<N> {
+        impl<N: Copy + Mul<N, Output = N>> Mul<N> for $t<N> {
+            type Output = $t<N>;
+
             #[inline]
             fn mul(self, right: N) -> $t<N> {
                 $t::new(self.$comp0 * right $(, self.$compN * right)*)
@@ -458,7 +473,9 @@ macro_rules! scalar_mul_impl(
 
 macro_rules! div_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
-        impl<N: Copy + Div<N, N>> Div<$t<N>, $t<N>> for $t<N> {
+        impl<N: Copy + Div<N, Output = N>> Div<$t<N>> for $t<N> {
+            type Output = $t<N>;
+
             #[inline]
             fn div(self, right: $t<N>) -> $t<N> {
                 $t::new(self.$comp0 / right.$comp0 $(, self.$compN / right.$compN)*)
@@ -469,7 +486,9 @@ macro_rules! div_impl(
 
 macro_rules! scalar_div_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
-        impl<N: Copy + Div<N, N>> Div<N, $t<N>> for $t<N> {
+        impl<N: Copy + Div<N, Output = N>> Div<N> for $t<N> {
+            type Output = $t<N>;
+
             #[inline]
             fn div(self, right: N) -> $t<N> {
                 $t::new(self.$comp0 / right $(, self.$compN / right)*)
@@ -480,7 +499,9 @@ macro_rules! scalar_div_impl(
 
 macro_rules! neg_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
-        impl<N: Neg<N> + Copy> Neg<$t<N>> for $t<N> {
+        impl<N: Neg<Output = N> + Copy> Neg for $t<N> {
+            type Output = $t<N>;
+
             #[inline]
             fn neg(self) -> $t<N> {
                 $t::new(-self.$comp0 $(, -self.$compN )*)
@@ -502,28 +523,28 @@ macro_rules! dot_impl(
 
 macro_rules! scalar_ops_impl(
     ($t: ident, $comp0: ident $(,$compN: ident)*) => (
-        impl<N: Copy + Mul<N, N>> ScalarMul<N> for $t<N> {
+        impl<N: Copy + Mul<N, Output = N>> ScalarMul<N> for $t<N> {
             #[inline]
             fn mul_s(&self, other: &N) -> $t<N> {
                 $t::new(self.$comp0 * *other $(, self.$compN * *other)*)
             }
         }
 
-        impl<N: Copy + Div<N, N>> ScalarDiv<N> for $t<N> {
+        impl<N: Copy + Div<N, Output = N>> ScalarDiv<N> for $t<N> {
             #[inline]
             fn div_s(&self, other: &N) -> $t<N> {
                 $t::new(self.$comp0 / *other $(, self.$compN / *other)*)
             }
         }
 
-        impl<N: Copy + Add<N, N>> ScalarAdd<N> for $t<N> {
+        impl<N: Copy + Add<N, Output = N>> ScalarAdd<N> for $t<N> {
             #[inline]
             fn add_s(&self, other: &N) -> $t<N> {
                 $t::new(self.$comp0 + *other $(, self.$compN + *other)*)
             }
         }
 
-        impl<N: Copy + Sub<N, N>> ScalarSub<N> for $t<N> {
+        impl<N: Copy + Sub<N, Output = N>> ScalarSub<N> for $t<N> {
             #[inline]
             fn sub_s(&self, other: &N) -> $t<N> {
                 $t::new(self.$comp0 - *other $(, self.$compN - *other)*)
@@ -534,7 +555,7 @@ macro_rules! scalar_ops_impl(
 
 macro_rules! translation_impl(
     ($t: ident) => (
-        impl<N: Copy + Add<N, N> + Neg<N>> Translation<$t<N>> for $t<N> {
+        impl<N: Copy + Add<N, Output = N> + Neg<Output = N>> Translation<$t<N>> for $t<N> {
             #[inline]
             fn translation(&self) -> $t<N> {
                 *self
@@ -669,7 +690,7 @@ macro_rules! from_iterator_impl(
     ($t: ident, $param0: ident $(, $paramN: ident)*) => (
         impl<N> FromIterator<N> for $t<N> {
             #[inline]
-            fn from_iter<I: Iterator<N>>(mut $param0: I) -> $t<N> {
+            fn from_iter<I: Iterator<Item = N>>(mut $param0: I) -> $t<N> {
                 $t::new($param0.next().unwrap() $(, $paramN.next().unwrap())*)
             }
         }
@@ -715,7 +736,7 @@ macro_rules! vec_to_homogeneous_impl(
 
 macro_rules! vec_from_homogeneous_impl(
     ($t: ident, $t2: ident, $extra: ident, $comp0: ident $(,$compN: ident)*) => (
-        impl<N: Copy + Div<N, N> + One + Zero> FromHomogeneous<$t2<N>> for $t<N> {
+        impl<N: Copy + Div<N, Output = N> + One + Zero> FromHomogeneous<$t2<N>> for $t<N> {
             fn from(v: &$t2<N>) -> $t<N> {
                 let mut res: $t<N> = ::zero();
 
@@ -730,7 +751,7 @@ macro_rules! vec_from_homogeneous_impl(
 
 macro_rules! translate_impl(
     ($tv: ident, $t: ident) => (
-        impl<N: Copy + Add<N, N> + Sub<N, N>> Translate<$t<N>> for $tv<N> {
+        impl<N: Copy + Add<N, Output = N> + Sub<N, Output = N>> Translate<$t<N>> for $tv<N> {
             fn translate(&self, other: &$t<N>) -> $t<N> {
                 *other + *self
             }
@@ -758,7 +779,7 @@ macro_rules! rotate_impl(
 
 macro_rules! transform_impl(
     ($tv: ident, $t: ident) => (
-        impl<N: Copy + Add<N, N> + Sub<N, N>> Transform<$t<N>> for $tv<N> {
+        impl<N: Copy + Add<N, Output = N> + Sub<N, Output = N>> Transform<$t<N>> for $tv<N> {
             fn transform(&self, other: &$t<N>) -> $t<N> {
                 self.translate(other)
             }

--- a/src/traits/geometry.rs
+++ b/src/traits/geometry.rs
@@ -82,7 +82,7 @@ pub trait Rotate<V> {
 ///
 /// Those operations are automatically implemented in term of the `Rotation` and `Translation`
 /// traits.
-pub trait RotationWithTranslation<LV: Neg<LV> + Copy, AV>: Rotation<AV> + Translation<LV> + Sized {
+pub trait RotationWithTranslation<LV: Neg<Output = LV> + Copy, AV>: Rotation<AV> + Translation<LV> + Sized {
     /// Applies a rotation centered on a specific point.
     ///
     /// # Arguments
@@ -136,14 +136,16 @@ pub trait RotationWithTranslation<LV: Neg<LV> + Copy, AV>: Rotation<AV> + Transl
     }
 }
 
-impl<LV: Neg<LV> + Copy, AV, M: Rotation<AV> + Translation<LV>> RotationWithTranslation<LV, AV> for M {
+impl<LV: Neg<Output = LV> + Copy, AV, M: Rotation<AV> + Translation<LV>> RotationWithTranslation<LV, AV> for M {
 }
 
 /// Trait of transformation having a rotation extractable as a rotation matrix. This can typically
 /// be implemented by quaternions to convert them to a rotation matrix.
-pub trait RotationMatrix<N, LV, AV, M: Mat<N, LV, LV> + Rotation<AV>> : Rotation<AV> {
+pub trait RotationMatrix<N, LV, AV> : Rotation<AV> {
+    type Output: Mat<N, LV, LV> + Rotation<AV>;
+
     /// Gets the rotation matrix represented by `self`.
-    fn to_rot_mat(&self) -> M;
+    fn to_rot_mat(&self) -> Self::Output;
 }
 
 /// Composition of a rotation and an absolute value.
@@ -227,9 +229,11 @@ pub trait Norm<N: BaseFloat> {
 /**
  * Trait of elements having a cross product.
  */
-pub trait Cross<V> {
+pub trait Cross {
+    type Output;
+
     /// Computes the cross product between two elements (usually vectors).
-    fn cross(&self, other: &Self) -> V;
+    fn cross(&self, other: &Self) -> Self::Output;
 }
 
 /**

--- a/src/traits/operations.rs
+++ b/src/traits/operations.rs
@@ -314,7 +314,7 @@ pub trait RMul<V> {
     fn rmul(&self, v: &V) -> V;
 }
 
-impl<M: Copy + Mul<T, T>, T: Copy> RMul<T> for M {
+impl<M: Copy + Mul<T, Output = T>, T: Copy> RMul<T> for M {
     fn rmul(&self, v: &T) -> T {
         *self * *v
     }
@@ -326,7 +326,7 @@ pub trait LMul<V> {
     fn lmul(&self, &V) -> V;
 }
 
-impl<T: Copy + Mul<M, T>, M: Copy> LMul<T> for M {
+impl<T: Copy + Mul<M, Output = T>, M: Copy> LMul<T> for M {
     fn lmul(&self, v: &T) -> T {
         *v * *self
     }

--- a/src/traits/structure.rs
+++ b/src/traits/structure.rs
@@ -9,9 +9,11 @@ use traits::operations::{RMul, LMul, Axpy, Transpose, Inv, Absolute};
 use traits::geometry::{Dot, Norm, Orig};
 
 /// Basic integral numeric trait.
-pub trait BaseNum: Copy + Zero + One + Add<Self, Self> + Sub<Self, Self> + Mul<Self, Self> +
-                   Div<Self, Self> + Rem<Self, Self> + Neg<Self> + PartialEq + Absolute<Self> +
-                   Axpy<Self> {
+pub trait BaseNum: Copy + Zero + One +
+                   Add<Self, Output = Self> + Sub<Self, Output = Self> +
+                   Mul<Self, Output = Self> + Div<Self, Output = Self> +
+                   Rem<Self, Output = Self> + Neg<Output = Self> + PartialEq +
+                   Absolute<Self> + Axpy<Self> {
 }
 
 /// Basic floating-point number numeric trait.
@@ -58,19 +60,19 @@ pub trait Cast<T> {
 /// Trait of matrices.
 ///
 /// A matrix has rows and columns and are able to multiply them.
-pub trait Mat<N, R, C>: Row<R> + Col<C> + RMul<R> + LMul<C> + Index<(uint, uint), N> { }
+pub trait Mat<N, R, C>: Row<R> + Col<C> + RMul<R> + LMul<C> + Index<(uint, uint), Output = N> { }
 
 impl<N, M, R, C> Mat<N, R, C> for M
-    where M: Row<R> + Col<C> + RMul<R> + LMul<C> + Index<(uint, uint), N> {
+    where M: Row<R> + Col<C> + RMul<R> + LMul<C> + Index<(uint, uint), Output = N> {
 }
 
 /// Trait implemented by square matrices.
-pub trait SquareMat<N, V>: Mat<N, V, V> + Mul<Self, Self> + Eye + Transpose + Diag<V> + Inv + Dim +
-                           One {
+pub trait SquareMat<N, V>: Mat<N, V, V> +
+                           Mul<Self, Output = Self> + Eye + Transpose + Diag<V> + Inv + Dim + One {
 }
 
 impl<N, V, M> SquareMat<N, V> for M
-    where M: Mat<N, V, V> + Mul<M, M> + Eye + Transpose + Diag<V> + Inv + Dim + One {
+    where M: Mat<N, V, V> + Mul<M, Output = M> + Eye + Transpose + Diag<V> + Inv + Dim + One {
 }
 
 /// Trait for constructing the identity matrix
@@ -175,7 +177,7 @@ pub trait Diag<V> {
 }
 
 /// The shape of an indexable object.
-pub trait Shape<I, Res>: Index<I, Res> {
+pub trait Shape<I>: Index<I> {
     /// Returns the shape of an indexable object.
     fn shape(&self) -> I;
 }
@@ -185,24 +187,24 @@ pub trait Shape<I, Res>: Index<I, Res> {
 /// It exists because the `I` trait cannot be used to express write access.
 /// Thus, this is the same as the `I` trait but without the syntactic sugar and with a method
 /// to write to a specific index.
-pub trait Indexable<I, Res>: Shape<I, Res> + IndexMut<I, Res> {
+pub trait Indexable<I, N>: Shape<I> + IndexMut<I, Output = N> {
     #[deprecated = "use the Index `[]` overloaded operator instead"]
     /// Reads the `i`-th element of `self`.
-    fn at(&self, i: I) -> Res;
+    fn at(&self, i: I) -> N;
     #[deprecated = "use the IndexMut `[]` overloaded operator instead"]
     /// Writes to the `i`-th element of `self`.
-    fn set(&mut self, i: I, Res);
+    fn set(&mut self, i: I, N);
     /// Swaps the `i`-th element of `self` with its `j`-th element.
     fn swap(&mut self, i: I, j: I);
 
     /// Reads the `i`-th element of `self`.
     ///
     /// `i` is not checked.
-    unsafe fn unsafe_at(&self, i: I) -> Res;
+    unsafe fn unsafe_at(&self, i: I) -> N;
     /// Writes to the `i`-th element of `self`.
     ///
     /// `i` is not checked.
-    unsafe fn unsafe_set(&mut self, i: I, Res);
+    unsafe fn unsafe_set(&mut self, i: I, N);
 }
 
 /// This is a workaround of current Rust limitations.
@@ -235,8 +237,12 @@ pub trait VecAsPnt<P> {
 }
 
 /// Trait grouping most common operations on vectors.
-pub trait NumVec<N>: Dim + Sub<Self, Self> + Add<Self, Self> + Neg<Self> + Zero + PartialEq +
-                     Mul<N, Self> + Div<N, Self> + Dot<N> + Axpy<N> + Index<uint, N> {
+pub trait NumVec<N>: Dim +
+                     Sub<Self, Output = Self> + Add<Self, Output = Self> +
+                     Mul<N, Output = Self> + Div<N, Output = Self> + 
+                     Neg<Output = Self> +
+                     Index<uint, Output = N> +
+                     Zero + PartialEq + Dot<N> + Axpy<N> {
 }
 
 /// Trait of vector with components implementing the `BaseFloat` trait.
@@ -264,8 +270,18 @@ pub trait PntAsVec<V> {
 // XXX: the vector space element `V` should be an associated type. Though this would prevent V from
 // having bounds (they are not supported yet). So, for now, we will just use a type parameter.
 pub trait NumPnt<N, V>:
-          Copy + PntAsVec<V> + Dim + Sub<Self, V> + Orig + Neg<Self> + PartialEq + Mul<N, Self> +
-          Div<N, Self> + Add<V, Self> + Axpy<N> + Index<uint, N> { // FIXME: + Sub<V, Self>
+          Copy +
+          PntAsVec<V> +
+          Dim +
+          Orig +
+          PartialEq +
+          Axpy<N> +
+          Sub<Self, Output = V> +
+          Neg<Output = Self>    +
+          Mul<N, Output = Self> +
+          Div<N, Output = Self> +
+          Add<V, Output = Self> +
+          Index<uint, Output = N> { // FIXME: + Sub<V, Self>
 }
 
 /// Trait of points with components implementing the `BaseFloat` trait.


### PR DESCRIPTION
Version of rustc: 0.13.0-nightly (c6c786671 2015-01-04 00:50:59 +0000).

This also changes the `Cross` trait to use an associated type for its output (this is needed for `ncollide`).

Many other traits will benefit from associated type, but I delay those modifications until things start to break less frequently on the language side.