### PR TITLE
Change Fn to FnMut

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -750,7 +750,7 @@ pub fn from_homogeneous<M, Res: FromHomogeneous<M>>(m: &M) -> Res {
 ///
 /// The number of sampling point is implementation-specific. It is always uniform.
 #[inline(always)]
-pub fn sample_sphere<V: UniformSphereSample, F: Fn(V)>(f: F) {
+pub fn sample_sphere<V: UniformSphereSample, F: FnMut(V)>(f: F) {
     UniformSphereSample::sample(f)
 }
 
@@ -866,13 +866,13 @@ pub fn new_identity<M: Eye>(dim: uint) -> M {
 
 /// Computes the canonical basis for a given dimension.
 #[inline(always)]
-pub fn canonical_basis<V: Basis, F: Fn(V) -> bool>(f: F) {
+pub fn canonical_basis<V: Basis, F: FnMut(V) -> bool>(f: F) {
     Basis::canonical_basis(f)
 }
 
 /// Computes the basis of the orthonormal subspace of a given vector.
 #[inline(always)]
-pub fn orthonormal_subspace_basis<V: Basis, F: Fn(V) -> bool>(v: &V, f: F) {
+pub fn orthonormal_subspace_basis<V: Basis, F: FnMut(V) -> bool>(v: &V, f: F) {
     Basis::orthonormal_subspace_basis(v, f)
 }
 

--- a/src/structs/dmat.rs
+++ b/src/structs/dmat.rs
@@ -127,7 +127,7 @@ impl<N: Clone + Copy> DMat<N> {
 impl<N> DMat<N> {
     /// Builds a matrix filled with a given constant.
     #[inline(always)]
-    pub fn from_fn<F: Fn(uint, uint) -> N>(nrows: uint, ncols: uint, f: F) -> DMat<N> {
+    pub fn from_fn<F: FnMut(uint, uint) -> N>(nrows: uint, ncols: uint, mut f: F) -> DMat<N> {
         DMat {
             nrows: nrows,
             ncols: ncols,

--- a/src/structs/dvec.rs
+++ b/src/structs/dvec.rs
@@ -55,7 +55,7 @@ impl<N: Clone> DVec<N> {
 impl<N> DVec<N> {
     /// Builds a vector filled with the result of a function.
     #[inline(always)]
-    pub fn from_fn<F: Fn(uint) -> N>(dim: uint, f: F) -> DVec<N> {
+    pub fn from_fn<F: FnMut(uint) -> N>(dim: uint, mut f: F) -> DVec<N> {
         DVec { at: range(0, dim).map(|i| f(i)).collect() }
     }
 

--- a/src/structs/dvec_macros.rs
+++ b/src/structs/dvec_macros.rs
@@ -481,7 +481,7 @@ macro_rules! small_dvec_from_impl (
         impl<N: Zero> $dvec<N> {
             /// Builds a vector filled with the result of a function.
             #[inline(always)]
-            pub fn from_fn<F: Fn(uint) -> N>(dim: uint, f: F) -> $dvec<N> {
+            pub fn from_fn<F: FnMut(uint) -> N>(dim: uint, mut f: F) -> $dvec<N> {
                 assert!(dim <= $dim);
 
                 let mut at: [N; $dim] = [ $( $zeros, )* ];

--- a/src/structs/spec/vec.rs
+++ b/src/structs/spec/vec.rs
@@ -74,12 +74,12 @@ impl<N: Copy> Row<Vec1<N>> for Vec2<N> {
 
 impl<N: One> Basis for Vec1<N> {
     #[inline(always)]
-    fn canonical_basis<F: Fn(Vec1<N>) -> bool>(f: F) {
+    fn canonical_basis<F: FnMut(Vec1<N>) -> bool>(mut f: F) {
         f(Vec1::new(::one()));
     }
 
     #[inline(always)]
-    fn orthonormal_subspace_basis<F: Fn(Vec1<N>) -> bool>(_: &Vec1<N>, _: F) { }
+    fn orthonormal_subspace_basis<F: FnMut(Vec1<N>) -> bool>(_: &Vec1<N>, _: F) { }
 
     #[inline]
     fn canonical_basis_element(i: uint) -> Option<Vec1<N>> {
@@ -94,13 +94,13 @@ impl<N: One> Basis for Vec1<N> {
 
 impl<N: Copy + One + Zero + Neg<Output = N>> Basis for Vec2<N> {
     #[inline(always)]
-    fn canonical_basis<F: Fn(Vec2<N>) -> bool>(f: F) {
+    fn canonical_basis<F: FnMut(Vec2<N>) -> bool>(mut f: F) {
         if !f(Vec2::new(::one(), ::zero())) { return };
         f(Vec2::new(::zero(), ::one()));
     }
 
     #[inline]
-    fn orthonormal_subspace_basis<F: Fn(Vec2<N>) -> bool>(n: &Vec2<N>, f: F) {
+    fn orthonormal_subspace_basis<F: FnMut(Vec2<N>) -> bool>(n: &Vec2<N>, mut f: F) {
         f(Vec2::new(-n.y, n.x));
     }
 
@@ -120,14 +120,14 @@ impl<N: Copy + One + Zero + Neg<Output = N>> Basis for Vec2<N> {
 
 impl<N: BaseFloat> Basis for Vec3<N> {
     #[inline(always)]
-    fn canonical_basis<F: Fn(Vec3<N>) -> bool>(f: F) {
+    fn canonical_basis<F: FnMut(Vec3<N>) -> bool>(mut f: F) {
         if !f(Vec3::new(::one(), ::zero(), ::zero())) { return };
         if !f(Vec3::new(::zero(), ::one(), ::zero())) { return };
         f(Vec3::new(::zero(), ::zero(), ::one()));
     }
 
     #[inline(always)]
-    fn orthonormal_subspace_basis<F: Fn(Vec3<N>) -> bool>(n: &Vec3<N>, f: F) {
+    fn orthonormal_subspace_basis<F: FnMut(Vec3<N>) -> bool>(n: &Vec3<N>, mut f: F) {
         let a = 
             if n.x.abs() > n.y.abs() {
                 Norm::normalize_cpy(&Vec3::new(n.z, ::zero(), -n.x))
@@ -230,14 +230,14 @@ static SAMPLES_3_F64: [Vec3<f64>; 42] = [
 
 impl<N: One + Copy> UniformSphereSample for Vec1<N> {
     #[inline(always)]
-    fn sample<F: Fn(Vec1<N>)>(f: F) {
+    fn sample<F: FnMut(Vec1<N>)>(mut f: F) {
         f(::one())
      }
 }
 
 impl<N: Cast<f64> + Copy> UniformSphereSample for Vec2<N> {
     #[inline(always)]
-    fn sample<F: Fn(Vec2<N>)>(f: F) {
+    fn sample<F: FnMut(Vec2<N>)>(mut f: F) {
          for sample in SAMPLES_2_F64.iter() {
              f(Cast::from(*sample))
          }
@@ -246,7 +246,7 @@ impl<N: Cast<f64> + Copy> UniformSphereSample for Vec2<N> {
 
 impl<N: Cast<f64> + Copy> UniformSphereSample for Vec3<N> {
     #[inline(always)]
-    fn sample<F: Fn(Vec3<N>)>(f: F) {
+    fn sample<F: FnMut(Vec3<N>)>(mut f: F) {
         for sample in SAMPLES_3_F64.iter() {
             f(Cast::from(*sample))
         }
@@ -255,7 +255,7 @@ impl<N: Cast<f64> + Copy> UniformSphereSample for Vec3<N> {
 
 impl<N: Cast<f64> + Copy> UniformSphereSample for Vec4<N> {
     #[inline(always)]
-    fn sample<F: Fn(Vec4<N>)>(_: F) {
+    fn sample<F: FnMut(Vec4<N>)>(_: F) {
         panic!("UniformSphereSample::<Vec4<N>>::sample : Not yet implemented.")
         // for sample in SAMPLES_3_F32.iter() {
         //     f(Cast::from(*sample))

--- a/src/structs/spec/vec0.rs
+++ b/src/structs/spec/vec0.rs
@@ -92,10 +92,10 @@ impl<N> Dim for vec::Vec0<N> {
 
 impl<N> Basis for vec::Vec0<N> {
     #[inline(always)]
-    fn canonical_basis<F: Fn(vec::Vec0<N>) -> bool>(_: F) { }
+    fn canonical_basis<F: FnMut(vec::Vec0<N>) -> bool>(_: F) { }
 
     #[inline(always)]
-    fn orthonormal_subspace_basis<F: Fn(vec::Vec0<N>) -> bool>(_: &vec::Vec0<N>, _: F) { }
+    fn orthonormal_subspace_basis<F: FnMut(vec::Vec0<N>) -> bool>(_: &vec::Vec0<N>, _: F) { }
 
     #[inline(always)]
     fn canonical_basis_element(_: uint) -> Option<vec::Vec0<N>> {

--- a/src/structs/vec_macros.rs
+++ b/src/structs/vec_macros.rs
@@ -321,14 +321,14 @@ macro_rules! basis_impl(
     ($t: ident, $dim: expr) => (
         impl<N: Copy + BaseFloat + ApproxEq<N>> Basis for $t<N> {
             #[inline]
-            fn canonical_basis<F: Fn($t<N>) -> bool>(f: F) {
+            fn canonical_basis<F: FnMut($t<N>) -> bool>(mut f: F) {
                 for i in range(0u, $dim) {
                     if !f(Basis::canonical_basis_element(i).unwrap()) { return }
                 }
             }
 
             #[inline]
-            fn orthonormal_subspace_basis<F: Fn($t<N>) -> bool>(n: &$t<N>, f: F) {
+            fn orthonormal_subspace_basis<F: FnMut($t<N>) -> bool>(n: &$t<N>, mut f: F) {
                 // compute the basis of the orthogonal subspace using Gram-Schmidt
                 // orthogonalization algorithm
                 let mut basis: Vec<$t<N>> = Vec::new();

--- a/src/traits/geometry.rs
+++ b/src/traits/geometry.rs
@@ -266,7 +266,7 @@ pub trait FromHomogeneous<U> {
 /// function.
 pub trait UniformSphereSample {
     /// Iterate through the samples.
-    fn sample<F: Fn(Self)>(F);
+    fn sample<F: FnMut(Self)>(F);
 }
 
 /// The zero element of a vector space, seen as an element of its embeding affine space.

--- a/src/traits/structure.rs
+++ b/src/traits/structure.rs
@@ -109,10 +109,10 @@ pub trait Bounded {
 /// Traits of objects which can form a basis (typically vectors).
 pub trait Basis {
     /// Iterates through the canonical basis of the space in which this object lives.
-    fn canonical_basis<F: Fn(Self) -> bool>(F);
+    fn canonical_basis<F: FnMut(Self) -> bool>(F);
 
     /// Iterates through a basis of the subspace orthogonal to `self`.
-    fn orthonormal_subspace_basis<F: Fn(Self) -> bool>(&Self, F);
+    fn orthonormal_subspace_basis<F: FnMut(Self) -> bool>(&Self, F);
 
     /// Gets the ith element of the canonical basis.
     fn canonical_basis_element(i: uint) -> Option<Self>;


### PR DESCRIPTION
`Fn` was the wrong way to go because a closure like `|y| x = y` isn't a valid `Fn`, but it's a valid `FnMut` (because it captures the mutable external state of `x`).