### PR TITLE
fix warning from unneeded old_orphan_check

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,6 @@ Feel free to add your project to this list if you happen to use **nalgebra**!
 #![deny(unused_results)]
  #![allow(unstable)]
 #![warn(missing_docs)]
-#![feature(old_orphan_check)]
 #![feature(unboxed_closures)]
 #![doc(html_root_url = "http://nalgebra.org/doc")]
 


### PR DESCRIPTION
trivial fix to remove deprecation warning in rustc 1.0.0-nightly (44a287e6e 2015-01-08 17:03:40 -0800):

src/lib.rs:86:12: 86:28 warning: feature is deprecated and will only be available for a limited time, please rewrite code that relies on it
src/lib.rs:86 #![feature(old_orphan_check)]
                         ^~~~~~~~~~~~~~~~