### PR TITLE
Rename similar in-place and copy methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ fn main() {
     let     a = Vec3::new(1.0f64, 1.0, 1.0);
     let mut b = Rot3::new(na::zero());
 
-    b.append_rotation(&a);
+    b.append_rotation_mut(&a);
 
     assert!(na::approx_eq(&na::rotation(&b), &a));
 }
@@ -407,7 +407,7 @@ pub fn inv_translation<V, M: Translation<V>>(m: &M) -> V {
 /// Applies the translation `v` to a copy of `m`.
 #[inline(always)]
 pub fn append_translation<V, M: Translation<V>>(m: &M, v: &V) -> M {
-    Translation::append_translation_cpy(m, v)
+    Translation::append_translation(m, v)
 }
 
 /*
@@ -509,7 +509,7 @@ pub fn inv_rotation<V, M: Rotation<V>>(m: &M) -> V {
 /// ```
 #[inline(always)]
 pub fn append_rotation<V, M: Rotation<V>>(m: &M, v: &V) -> M {
-    Rotation::append_rotation_cpy(m, v)
+    Rotation::append_rotation(m, v)
 }
 
 // FIXME: this example is a bit shity
@@ -529,7 +529,7 @@ pub fn append_rotation<V, M: Rotation<V>>(m: &M, v: &V) -> M {
 /// ```
 #[inline(always)]
 pub fn prepend_rotation<V, M: Rotation<V>>(m: &M, v: &V) -> M {
-    Rotation::prepend_rotation_cpy(m, v)
+    Rotation::prepend_rotation(m, v)
 }
 
 /*
@@ -589,7 +589,7 @@ pub fn append_rotation_wrt_point<LV: Neg<Output = LV> + Copy,
                                  m:      &M,
                                  amount: &AV,
                                  center: &LV) -> M {
-    RotationWithTranslation::append_rotation_wrt_point_cpy(m, amount, center)
+    RotationWithTranslation::append_rotation_wrt_point(m, amount, center)
 }
 
 /// Rotates a copy of `m` by `amount` using `m.translation()` as the pivot point.
@@ -599,7 +599,7 @@ pub fn append_rotation_wrt_center<LV: Neg<Output = LV> + Copy,
                                   M: RotationWithTranslation<LV, AV>>(
                                   m:      &M,
                                   amount: &AV) -> M {
-    RotationWithTranslation::append_rotation_wrt_center_cpy(m, amount)
+    RotationWithTranslation::append_rotation_wrt_center(m, amount)
 }
 
 /*
@@ -641,7 +641,7 @@ pub fn inv_transformation<T, M: Transformation<T>>(m: &M) -> T {
 /// Gets a transformed copy of `m`.
 #[inline(always)]
 pub fn append_transformation<T, M: Transformation<T>>(m: &M, t: &T) -> M {
-    Transformation::append_transformation_cpy(m, t)
+    Transformation::append_transformation(m, t)
 }
 
 /*
@@ -689,7 +689,7 @@ pub fn sqnorm<V: Norm<N>, N: BaseFloat>(v: &V) -> N {
 /// Gets the normalized version of a vector.
 #[inline(always)]
 pub fn normalize<V: Norm<N>, N: BaseFloat>(v: &V) -> V {
-    Norm::normalize_cpy(v)
+    Norm::normalize(v)
 }
 
 /*
@@ -795,7 +795,7 @@ pub fn abs<M: Absolute<Res>, Res>(m: &M) -> Res {
 /// Gets an inverted copy of a matrix.
 #[inline(always)]
 pub fn inv<M: Inv>(m: &M) -> Option<M> {
-    Inv::inv_cpy(m)
+    Inv::inv(m)
 }
 
 /*
@@ -805,7 +805,7 @@ pub fn inv<M: Inv>(m: &M) -> Option<M> {
 /// Gets a transposed copy of a matrix.
 #[inline(always)]
 pub fn transpose<M: Transpose>(m: &M) -> M {
-    Transpose::transpose_cpy(m)
+    Transpose::transpose(m)
 }
 
 /*

--- a/src/linalg/decompositions.rs
+++ b/src/linalg/decompositions.rs
@@ -63,10 +63,10 @@ pub fn qr<N, V, M>(m: &M) -> (M, M)
             let x = v.unsafe_at(0);
             v.unsafe_set(0, x - alpha);
         }
-        if !::is_zero(&v.normalize()) {
+        if !::is_zero(&v.normalize_mut()) {
             let qk: M = householder_matrix(rows, ite, v);
             r = qk * r;
-            q = q * Transpose::transpose_cpy(&qk);
+            q = q * Transpose::transpose(&qk);
         }
     }
 

--- a/src/structs/dmat.rs
+++ b/src/structs/dmat.rs
@@ -103,7 +103,7 @@ impl<N: Clone + Copy> DMat<N> {
         let mut res = DMat::from_col_vec(ncols, nrows, vec);
 
         // we transpose because the buffer is row_major
-        res.transpose();
+        res.transpose_mut();
 
         res
     }
@@ -370,9 +370,9 @@ impl<N: Copy + Add<N, Output = N> + Mul<N, Output = N> + Zero> Mul<DMat<N>> for 
 
 impl<N: BaseNum + Clone> Inv for DMat<N> {
     #[inline]
-    fn inv_cpy(&self) -> Option<DMat<N>> {
+    fn inv(&self) -> Option<DMat<N>> {
         let mut res: DMat<N> = self.clone();
-        if res.inv() {
+        if res.inv_mut() {
             Some(res)
         }
         else {
@@ -380,7 +380,7 @@ impl<N: BaseNum + Clone> Inv for DMat<N> {
         }
     }
 
-    fn inv(&mut self) -> bool {
+    fn inv_mut(&mut self) -> bool {
         assert!(self.nrows == self.ncols);
 
         let dim              = self.nrows;
@@ -456,11 +456,11 @@ impl<N: BaseNum + Clone> Inv for DMat<N> {
 
 impl<N: Clone + Copy> Transpose for DMat<N> {
     #[inline]
-    fn transpose_cpy(&self) -> DMat<N> {
+    fn transpose(&self) -> DMat<N> {
         if self.nrows == self.ncols {
             let mut res = self.clone();
 
-            res.transpose();
+            res.transpose_mut();
 
             res
         }
@@ -480,7 +480,7 @@ impl<N: Clone + Copy> Transpose for DMat<N> {
     }
 
     #[inline]
-    fn transpose(&mut self) {
+    fn transpose_mut(&mut self) {
         if self.nrows == self.ncols {
             for i in (1us .. self.nrows) {
                 for j in (0us .. self.ncols - 1) {
@@ -495,7 +495,7 @@ impl<N: Clone + Copy> Transpose for DMat<N> {
         }
         else {
             // FIXME: implement a better algorithm which does that in-place.
-            *self = Transpose::transpose_cpy(self);
+            *self = Transpose::transpose(self);
         }
     }
 }
@@ -539,7 +539,7 @@ impl<N: BaseNum + Cast<f64> + Clone> Cov<DMat<N>> for DMat<N> {
         let fnormalizer: f64 = Cast::from(self.nrows() - 1);
         let normalizer: N    = Cast::from(fnormalizer);
         // FIXME: this will do 2 allocations for temporaries!
-        (Transpose::transpose_cpy(&centered) * centered) / normalizer
+        (Transpose::transpose(&centered) * centered) / normalizer
     }
 }
 

--- a/src/structs/dvec_macros.rs
+++ b/src/structs/dvec_macros.rs
@@ -184,7 +184,7 @@ macro_rules! dvec_impl(
                     };
 
                     if !ApproxEq::approx_eq(&Norm::sqnorm(&elt), &::zero()) {
-                        res.push(Norm::normalize_cpy(&elt));
+                        res.push(Norm::normalize(&elt));
                     }
                 }
 
@@ -290,14 +290,14 @@ macro_rules! dvec_impl(
             }
 
             #[inline]
-            fn normalize_cpy(&self) -> $dvec<N> {
+            fn normalize(&self) -> $dvec<N> {
                 let mut res : $dvec<N> = self.clone();
-                let _ = res.normalize();
+                let _ = res.normalize_mut();
                 res
             }
 
             #[inline]
-            fn normalize(&mut self) -> N {
+            fn normalize_mut(&mut self) -> N {
                 let l = Norm::norm(self);
 
                 for n in self.as_mut_slice().iter_mut() {

--- a/src/structs/iso_macros.rs
+++ b/src/structs/iso_macros.rs
@@ -115,22 +115,22 @@ macro_rules! translation_impl(
             }
 
             #[inline]
-            fn append_translation(&mut self, t: &$tv<N>) {
+            fn append_translation_mut(&mut self, t: &$tv<N>) {
                 self.translation = *t + self.translation
             }
 
             #[inline]
-            fn append_translation_cpy(&self, t: &$tv<N>) -> $t<N> {
+            fn append_translation(&self, t: &$tv<N>) -> $t<N> {
                 $t::new_with_rotmat(*t + self.translation, self.rotation)
             }
 
             #[inline]
-            fn prepend_translation(&mut self, t: &$tv<N>) {
+            fn prepend_translation_mut(&mut self, t: &$tv<N>) {
                 self.translation = self.translation + self.rotation * *t
             }
 
             #[inline]
-            fn prepend_translation_cpy(&self, t: &$tv<N>) -> $t<N> {
+            fn prepend_translation(&self, t: &$tv<N>) -> $t<N> {
                 $t::new_with_rotmat(self.translation + self.rotation * *t, self.rotation)
             }
 
@@ -172,7 +172,7 @@ macro_rules! rotation_impl(
             }
 
             #[inline]
-            fn append_rotation(&mut self, rot: &$tav<N>) {
+            fn append_rotation_mut(&mut self, rot: &$tav<N>) {
                 let delta = $trot::new(*rot);
 
                 self.rotation    = delta * self.rotation;
@@ -180,21 +180,21 @@ macro_rules! rotation_impl(
             }
 
             #[inline]
-            fn append_rotation_cpy(&self, rot: &$tav<N>) -> $t<N> {
+            fn append_rotation(&self, rot: &$tav<N>) -> $t<N> {
                 let delta = $trot::new(*rot);
 
                 $t::new_with_rotmat(delta * self.translation, delta * self.rotation)
             }
 
             #[inline]
-            fn prepend_rotation(&mut self, rot: &$tav<N>) {
+            fn prepend_rotation_mut(&mut self, rot: &$tav<N>) {
                 let delta = $trot::new(*rot);
 
                 self.rotation = self.rotation * delta;
             }
 
             #[inline]
-            fn prepend_rotation_cpy(&self, rot: &$tav<N>) -> $t<N> {
+            fn prepend_rotation(&self, rot: &$tav<N>) -> $t<N> {
                 let delta = $trot::new(*rot);
 
                 $t::new_with_rotmat(self.translation, self.rotation * delta)
@@ -234,22 +234,22 @@ macro_rules! transformation_impl(
 
             fn inv_transformation(&self) -> $t<N> {
                 // inversion will never fails
-                Inv::inv_cpy(self).unwrap()
+                Inv::inv(self).unwrap()
             }
 
-            fn append_transformation(&mut self, t: &$t<N>) {
+            fn append_transformation_mut(&mut self, t: &$t<N>) {
                 *self = *t * *self
             }
 
-            fn append_transformation_cpy(&self, t: &$t<N>) -> $t<N> {
+            fn append_transformation(&self, t: &$t<N>) -> $t<N> {
                 *t * *self
             }
 
-            fn prepend_transformation(&mut self, t: &$t<N>) {
+            fn prepend_transformation_mut(&mut self, t: &$t<N>) {
                 *self = *self * *t
             }
 
-            fn prepend_transformation_cpy(&self, t: &$t<N>) -> $t<N> {
+            fn prepend_transformation(&self, t: &$t<N>) -> $t<N> {
                 *self * *t
             }
 
@@ -280,17 +280,17 @@ macro_rules! inv_impl(
     ($t: ident) => (
         impl<N: BaseNum> Inv for $t<N> {
             #[inline]
-            fn inv(&mut self) -> bool {
-                self.rotation.inv();
+            fn inv_mut(&mut self) -> bool {
+                self.rotation.inv_mut();
                 self.translation = self.rotation * -self.translation;
                 // always succeed
                 true
             }
 
             #[inline]
-            fn inv_cpy(&self) -> Option<$t<N>> {
+            fn inv(&self) -> Option<$t<N>> {
                 let mut res = *self;
-                res.inv();
+                res.inv_mut();
                 // always succeed
                 Some(res)
             }

--- a/src/structs/mat_macros.rs
+++ b/src/structs/mat_macros.rs
@@ -532,9 +532,9 @@ macro_rules! inv_impl(
     impl<N: Copy + BaseNum>
     Inv for $t<N> {
         #[inline]
-        fn inv_cpy(&self) -> Option<$t<N>> {
+        fn inv(&self) -> Option<$t<N>> {
             let mut res : $t<N> = *self;
-            if res.inv() {
+            if res.inv_mut() {
                 Some(res)
             }
             else {
@@ -542,7 +542,7 @@ macro_rules! inv_impl(
             }
         }
 
-        fn inv(&mut self) -> bool {
+        fn inv_mut(&mut self) -> bool {
             let mut res: $t<N> = ::one();
 
             // inversion using Gauss-Jordan elimination
@@ -614,15 +614,15 @@ macro_rules! transpose_impl(
   ($t: ident, $dim: expr) => (
     impl<N: Copy> Transpose for $t<N> {
         #[inline]
-        fn transpose_cpy(&self) -> $t<N> {
+        fn transpose(&self) -> $t<N> {
             let mut res = *self;
 
-            res.transpose();
+            res.transpose_mut();
             res
         }
 
         #[inline]
-        fn transpose(&mut self) {
+        fn transpose_mut(&mut self) {
             for i in (1us .. $dim) {
                 for j in (0us .. i) {
                     self.swap((i, j), (j, i))

--- a/src/structs/rot.rs
+++ b/src/structs/rot.rs
@@ -44,22 +44,22 @@ impl<N: BaseFloat + Clone> Rotation<Vec1<N>> for Rot2<N> {
     }
 
     #[inline]
-    fn append_rotation(&mut self, rot: &Vec1<N>) {
-        *self = Rotation::append_rotation_cpy(self, rot)
+    fn append_rotation_mut(&mut self, rot: &Vec1<N>) {
+        *self = Rotation::append_rotation(self, rot)
     }
 
     #[inline]
-    fn append_rotation_cpy(&self, rot: &Vec1<N>) -> Rot2<N> {
+    fn append_rotation(&self, rot: &Vec1<N>) -> Rot2<N> {
         Rot2::new(rot.clone()) * *self
     }
 
     #[inline]
-    fn prepend_rotation(&mut self, rot: &Vec1<N>) {
-        *self = Rotation::prepend_rotation_cpy(self, rot)
+    fn prepend_rotation_mut(&mut self, rot: &Vec1<N>) {
+        *self = Rotation::prepend_rotation(self, rot)
     }
 
     #[inline]
-    fn prepend_rotation_cpy(&self, rot: &Vec1<N>) -> Rot2<N> {
+    fn prepend_rotation(&self, rot: &Vec1<N>) -> Rot2<N> {
         *self * Rot2::new(rot.clone())
     }
 
@@ -119,7 +119,7 @@ impl<N: Clone + BaseFloat> Rot3<N> {
         }
         else {
             let mut axis   = axisangle;
-            let angle      = axis.normalize();
+            let angle      = axis.normalize_mut();
             let _1: N      = ::one();
             let ux         = axis.x.clone();
             let uy         = axis.y.clone();
@@ -187,8 +187,8 @@ impl<N: Clone + BaseFloat> Rot3<N> {
     ///   * up - Vector pointing `up`. The only requirement of this parameter is to not be colinear
     ///   with `at`. Non-colinearity is not checked.
     pub fn look_at(&mut self, at: &Vec3<N>, up: &Vec3<N>) {
-        let xaxis = Norm::normalize_cpy(at);
-        let zaxis = Norm::normalize_cpy(&Cross::cross(up, &xaxis));
+        let xaxis = Norm::normalize(at);
+        let zaxis = Norm::normalize(&Cross::cross(up, &xaxis));
         let yaxis = Cross::cross(&zaxis, &xaxis);
 
         self.submat = Mat3::new(
@@ -204,8 +204,8 @@ impl<N: Clone + BaseFloat> Rot3<N> {
     ///   * up - Vector pointing `up`. The only requirement of this parameter is to not be colinear
     ///   with `at`. Non-colinearity is not checked.
     pub fn look_at_z(&mut self, at: &Vec3<N>, up: &Vec3<N>) {
-        let zaxis = Norm::normalize_cpy(at);
-        let xaxis = Norm::normalize_cpy(&Cross::cross(up, &zaxis));
+        let zaxis = Norm::normalize(at);
+        let xaxis = Norm::normalize(&Cross::cross(up, &zaxis));
         let yaxis = Cross::cross(&zaxis, &xaxis);
 
         self.submat = Mat3::new(
@@ -255,22 +255,22 @@ Rotation<Vec3<N>> for Rot3<N> {
 
 
     #[inline]
-    fn append_rotation(&mut self, rot: &Vec3<N>) {
-        *self = Rotation::append_rotation_cpy(self, rot)
+    fn append_rotation_mut(&mut self, rot: &Vec3<N>) {
+        *self = Rotation::append_rotation(self, rot)
     }
 
     #[inline]
-    fn append_rotation_cpy(&self, axisangle: &Vec3<N>) -> Rot3<N> {
+    fn append_rotation(&self, axisangle: &Vec3<N>) -> Rot3<N> {
         Rot3::new(axisangle.clone()) * *self
     }
 
     #[inline]
-    fn prepend_rotation(&mut self, rot: &Vec3<N>) {
-        *self = Rotation::prepend_rotation_cpy(self, rot)
+    fn prepend_rotation_mut(&mut self, rot: &Vec3<N>) {
+        *self = Rotation::prepend_rotation(self, rot)
     }
 
     #[inline]
-    fn prepend_rotation_cpy(&self, axisangle: &Vec3<N>) -> Rot3<N> {
+    fn prepend_rotation(&self, axisangle: &Vec3<N>) -> Rot3<N> {
         *self * Rot3::new(axisangle.clone())
     }
 
@@ -364,22 +364,22 @@ Rotation<Vec4<N>> for Rot4<N> {
     }
 
     #[inline]
-    fn append_rotation(&mut self, _: &Vec4<N>) {
+    fn append_rotation_mut(&mut self, _: &Vec4<N>) {
         panic!("Not yet implemented")
     }
 
     #[inline]
-    fn append_rotation_cpy(&self, _: &Vec4<N>) -> Rot4<N> {
+    fn append_rotation(&self, _: &Vec4<N>) -> Rot4<N> {
         panic!("Not yet implemented")
     }
 
     #[inline]
-    fn prepend_rotation(&mut self, _: &Vec4<N>) {
+    fn prepend_rotation_mut(&mut self, _: &Vec4<N>) {
         panic!("Not yet implemented")
     }
 
     #[inline]
-    fn prepend_rotation_cpy(&self, _: &Vec4<N>) -> Rot4<N> {
+    fn prepend_rotation(&self, _: &Vec4<N>) -> Rot4<N> {
         panic!("Not yet implemented")
     }
 

--- a/src/structs/rot_macros.rs
+++ b/src/structs/rot_macros.rs
@@ -157,17 +157,17 @@ macro_rules! inv_impl(
     ($t: ident) => (
         impl<N: Copy> Inv for $t<N> {
             #[inline]
-            fn inv(&mut self) -> bool {
-                self.transpose();
+            fn inv_mut(&mut self) -> bool {
+                self.transpose_mut();
 
                 // always succeed
                 true
             }
 
             #[inline]
-            fn inv_cpy(&self) -> Option<$t<N>> {
+            fn inv(&self) -> Option<$t<N>> {
                 // always succeed
-                Some(self.transpose_cpy())
+                Some(self.transpose())
             }
         }
     )
@@ -177,13 +177,13 @@ macro_rules! transpose_impl(
     ($t: ident) => (
         impl<N: Copy> Transpose for $t<N> {
             #[inline]
-            fn transpose_cpy(&self) -> $t<N> {
-                $t { submat: Transpose::transpose_cpy(&self.submat) }
+            fn transpose(&self) -> $t<N> {
+                $t { submat: Transpose::transpose(&self.submat) }
             }
 
             #[inline]
-            fn transpose(&mut self) {
-                self.submat.transpose()
+            fn transpose_mut(&mut self) {
+                self.submat.transpose_mut()
             }
         }
     )

--- a/src/structs/spec/complex.rs
+++ b/src/structs/spec/complex.rs
@@ -45,7 +45,7 @@ impl<N: Clone + BaseNum + BaseNumCast + Zero> Inv for Cmplx<N> {
 
 impl<N> Dim for Cmplx<N> {
     #[inline]
-    fn dim(unsused_self: Option<Cmplx<N>>) -> usize {
+    fn dim(unsused_mut: Option<Cmplx<N>>) -> usize {
         2
     }
 }

--- a/src/structs/spec/identity.rs
+++ b/src/structs/spec/identity.rs
@@ -13,11 +13,11 @@ impl One for mat::Identity {
 }
 
 impl Inv for mat::Identity {
-    fn inv_cpy(&self) -> Option<mat::Identity> {
+    fn inv(&self) -> Option<mat::Identity> {
         Some(mat::Identity::new())
     }
 
-    fn inv(&mut self) -> bool {
+    fn inv_mut(&mut self) -> bool {
         true
     }
 }
@@ -33,12 +33,12 @@ impl<T: Clone> Mul<T> for mat::Identity {
 
 impl Transpose for mat::Identity {
     #[inline]
-    fn transpose_cpy(&self) -> mat::Identity {
+    fn transpose(&self) -> mat::Identity {
         mat::Identity::new()
     }
 
     #[inline]
-    fn transpose(&mut self) {
+    fn transpose_mut(&mut self) {
     }
 }
 
@@ -54,22 +54,22 @@ impl<V: Zero> Translation<V> for mat::Identity {
     }
 
     #[inline]
-    fn append_translation(&mut self, _: &V) {
+    fn append_translation_mut(&mut self, _: &V) {
         panic!("Attempted to translate the identity matrix.")
     }
 
     #[inline]
-    fn append_translation_cpy(&self, _: &V) -> mat::Identity {
+    fn append_translation(&self, _: &V) -> mat::Identity {
         panic!("Attempted to translate the identity matrix.")
     }
 
     #[inline]
-    fn prepend_translation(&mut self, _: &V) {
+    fn prepend_translation_mut(&mut self, _: &V) {
         panic!("Attempted to translate the identity matrix.")
     }
 
     #[inline]
-    fn prepend_translation_cpy(&self, _: &V) -> mat::Identity {
+    fn prepend_translation(&self, _: &V) -> mat::Identity {
         panic!("Attempted to translate the identity matrix.")
     }
 
@@ -103,22 +103,22 @@ impl<V: Zero> Rotation<V> for mat::Identity {
     }
 
     #[inline]
-    fn append_rotation(&mut self, _: &V) {
+    fn append_rotation_mut(&mut self, _: &V) {
         panic!("Attempted to rotate the identity matrix.")
     }
 
     #[inline]
-    fn append_rotation_cpy(&self, _: &V) -> mat::Identity {
+    fn append_rotation(&self, _: &V) -> mat::Identity {
         panic!("Attempted to rotate the identity matrix.")
     }
 
     #[inline]
-    fn prepend_rotation(&mut self, _: &V) {
+    fn prepend_rotation_mut(&mut self, _: &V) {
         panic!("Attempted to rotate the identity matrix.")
     }
 
     #[inline]
-    fn prepend_rotation_cpy(&self, _: &V) -> mat::Identity {
+    fn prepend_rotation(&self, _: &V) -> mat::Identity {
         panic!("Attempted to rotate the identity matrix.")
     }
 
@@ -159,22 +159,22 @@ impl<M: One> Transformation<M> for mat::Identity {
     }
 
     #[inline]
-    fn append_transformation(&mut self, _: &M) {
+    fn append_transformation_mut(&mut self, _: &M) {
         panic!("Attempted to transform the identity matrix.")
     }
 
     #[inline]
-    fn append_transformation_cpy(&self, _: &M) -> mat::Identity {
+    fn append_transformation(&self, _: &M) -> mat::Identity {
         panic!("Attempted to transform the identity matrix.")
     }
 
     #[inline]
-    fn prepend_transformation(&mut self, _: &M) {
+    fn prepend_transformation_mut(&mut self, _: &M) {
         panic!("Attempted to transform the identity matrix.")
     }
 
     #[inline]
-    fn prepend_transformation_cpy(&self, _: &M) -> mat::Identity {
+    fn prepend_transformation(&self, _: &M) -> mat::Identity {
         panic!("Attempted to transform the identity matrix.")
     }
 

--- a/src/structs/spec/mat.rs
+++ b/src/structs/spec/mat.rs
@@ -8,9 +8,9 @@ use traits::structure::{Row, Col, BaseNum};
 // some specializations:
 impl<N: BaseNum + ApproxEq<N>> Inv for Mat1<N> {
     #[inline]
-    fn inv_cpy(&self) -> Option<Mat1<N>> {
+    fn inv(&self) -> Option<Mat1<N>> {
         let mut res = *self;
-        if res.inv() {
+        if res.inv_mut() {
             Some(res)
         }
         else {
@@ -19,7 +19,7 @@ impl<N: BaseNum + ApproxEq<N>> Inv for Mat1<N> {
     }
 
     #[inline]
-    fn inv(&mut self) -> bool {
+    fn inv_mut(&mut self) -> bool {
         if ApproxEq::approx_eq(&self.m11, &::zero()) {
             false
         }
@@ -34,9 +34,9 @@ impl<N: BaseNum + ApproxEq<N>> Inv for Mat1<N> {
 
 impl<N: BaseNum + ApproxEq<N>> Inv for Mat2<N> {
     #[inline]
-    fn inv_cpy(&self) -> Option<Mat2<N>> {
+    fn inv(&self) -> Option<Mat2<N>> {
         let mut res = *self;
-        if res.inv() {
+        if res.inv_mut() {
             Some(res)
         }
         else {
@@ -45,7 +45,7 @@ impl<N: BaseNum + ApproxEq<N>> Inv for Mat2<N> {
     }
 
     #[inline]
-    fn inv(&mut self) -> bool {
+    fn inv_mut(&mut self) -> bool {
         let det = Det::det(self);
 
         if ApproxEq::approx_eq(&det, &::zero()) {
@@ -63,10 +63,10 @@ impl<N: BaseNum + ApproxEq<N>> Inv for Mat2<N> {
 
 impl<N: BaseNum + ApproxEq<N>> Inv for Mat3<N> {
     #[inline]
-    fn inv_cpy(&self) -> Option<Mat3<N>> {
+    fn inv(&self) -> Option<Mat3<N>> {
         let mut res = *self;
 
-        if res.inv() {
+        if res.inv_mut() {
             Some(res)
         }
         else {
@@ -75,7 +75,7 @@ impl<N: BaseNum + ApproxEq<N>> Inv for Mat3<N> {
     }
 
     #[inline]
-    fn inv(&mut self) -> bool {
+    fn inv_mut(&mut self) -> bool {
         let minor_m12_m23 = self.m22 * self.m33 - self.m32 * self.m23;
         let minor_m11_m23 = self.m21 * self.m33 - self.m31 * self.m23;
         let minor_m11_m22 = self.m21 * self.m32 - self.m31 * self.m22;

--- a/src/structs/spec/vec.rs
+++ b/src/structs/spec/vec.rs
@@ -130,10 +130,10 @@ impl<N: BaseFloat> Basis for Vec3<N> {
     fn orthonormal_subspace_basis<F: FnMut(Vec3<N>) -> bool>(n: &Vec3<N>, mut f: F) {
         let a = 
             if n.x.abs() > n.y.abs() {
-                Norm::normalize_cpy(&Vec3::new(n.z, ::zero(), -n.x))
+                Norm::normalize(&Vec3::new(n.z, ::zero(), -n.x))
             }
             else {
-                Norm::normalize_cpy(&Vec3::new(::zero(), -n.z, n.y))
+                Norm::normalize(&Vec3::new(::zero(), -n.z, n.y))
             };
 
         if !f(Cross::cross(&a, n)) { return };

--- a/src/structs/spec/vec0.rs
+++ b/src/structs/spec/vec0.rs
@@ -167,22 +167,22 @@ impl<N: Copy + Add<N, Output = N> + Neg<Output = N>> Translation<vec::Vec0<N>> f
     }
 
     #[inline]
-    fn append_translation(&mut self, t: &vec::Vec0<N>) {
+    fn append_translation_mut(&mut self, t: &vec::Vec0<N>) {
         *self = *t + *self;
     }
 
     #[inline]
-    fn append_translation_cpy(&self, t: &vec::Vec0<N>) -> vec::Vec0<N> {
+    fn append_translation(&self, t: &vec::Vec0<N>) -> vec::Vec0<N> {
         *t + self
     }
 
     #[inline]
-    fn prepend_translation(&mut self, t: &vec::Vec0<N>) {
+    fn prepend_translation_mut(&mut self, t: &vec::Vec0<N>) {
         *self = *self + *t;
     }
 
     #[inline]
-    fn prepend_translation_cpy(&self, t: &vec::Vec0<N>) -> vec::Vec0<N> {
+    fn prepend_translation(&self, t: &vec::Vec0<N>) -> vec::Vec0<N> {
         *self + *t
     }
 
@@ -203,12 +203,12 @@ impl<N: BaseFloat> Norm<N> for vec::Vec0<N> {
     }
 
     #[inline]
-    fn normalize_cpy(&self) -> vec::Vec0<N> {
+    fn normalize(&self) -> vec::Vec0<N> {
         ::zero()
     }
 
     #[inline]
-    fn normalize(&mut self) -> N {
+    fn normalize_mut(&mut self) -> N {
         ::zero()
     }
 }

--- a/src/structs/vec_macros.rs
+++ b/src/structs/vec_macros.rs
@@ -341,7 +341,7 @@ macro_rules! basis_impl(
                     };
 
                     if !ApproxEq::approx_eq(&Norm::sqnorm(&elt), &::zero()) {
-                        let new_element = Norm::normalize_cpy(&elt);
+                        let new_element = Norm::normalize(&elt);
 
                         if !f(new_element) { return };
 
@@ -566,22 +566,22 @@ macro_rules! translation_impl(
             }
 
             #[inline]
-            fn append_translation(&mut self, t: &$t<N>) {
+            fn append_translation_mut(&mut self, t: &$t<N>) {
                 *self = *t + *self;
             }
 
             #[inline]
-            fn append_translation_cpy(&self, t: &$t<N>) -> $t<N> {
+            fn append_translation(&self, t: &$t<N>) -> $t<N> {
                 *t + *self
             }
 
             #[inline]
-            fn prepend_translation(&mut self, t: &$t<N>) {
+            fn prepend_translation_mut(&mut self, t: &$t<N>) {
                 *self = *self + *t;
             }
 
             #[inline]
-            fn prepend_translation_cpy(&self, t: &$t<N>) -> $t<N> {
+            fn prepend_translation(&self, t: &$t<N>) -> $t<N> {
                 *self + *t
             }
 
@@ -602,14 +602,14 @@ macro_rules! norm_impl(
             }
 
             #[inline]
-            fn normalize_cpy(&self) -> $t<N> {
+            fn normalize(&self) -> $t<N> {
                 let mut res : $t<N> = *self;
-                let _ = res.normalize();
+                let _ = res.normalize_mut();
                 res
             }
 
             #[inline]
-            fn normalize(&mut self) -> N {
+            fn normalize_mut(&mut self) -> N {
                 let l = Norm::norm(self);
 
                 $(self.$compN = self.$compN / l;)*

--- a/src/traits/geometry.rs
+++ b/src/traits/geometry.rs
@@ -14,16 +14,16 @@ pub trait Translation<V> {
     fn inv_translation(&self) -> V;
 
     /// Appends a translation to this object.
-    fn append_translation(&mut self, &V);
+    fn append_translation_mut(&mut self, &V);
 
     /// Appends the translation `amount` to a copy of `t`.
-    fn append_translation_cpy(&self, amount: &V) -> Self;
+    fn append_translation(&self, amount: &V) -> Self;
 
     /// Prepends a translation to this object.
-    fn prepend_translation(&mut self, &V);
+    fn prepend_translation_mut(&mut self, &V);
 
     /// Prepends the translation `amount` to a copy of `t`.
-    fn prepend_translation_cpy(&self, amount: &V) -> Self;
+    fn prepend_translation(&self, amount: &V) -> Self;
 
     /// Sets the translation.
     fn set_translation(&mut self, V);
@@ -49,16 +49,16 @@ pub trait Rotation<V> {
     fn inv_rotation(&self) -> V;
 
     /// Appends a rotation to this object.
-    fn append_rotation(&mut self, &V);
+    fn append_rotation_mut(&mut self, &V);
 
     /// Appends the rotation `amount` to a copy of `t`.
-    fn append_rotation_cpy(&self, amount: &V) -> Self;
+    fn append_rotation(&self, amount: &V) -> Self;
 
     /// Prepends a rotation to this object.
-    fn prepend_rotation(&mut self, &V);
+    fn prepend_rotation_mut(&mut self, &V);
 
     /// Prepends the rotation `amount` to a copy of `t`.
-    fn prepend_rotation_cpy(&self, amount: &V) -> Self;
+    fn prepend_rotation(&self, amount: &V) -> Self;
 
     /// Sets the rotation of `self`.
     fn set_rotation(&mut self, V);
@@ -90,11 +90,11 @@ pub trait RotationWithTranslation<LV: Neg<Output = LV> + Copy, AV>: Rotation<AV>
     ///   * `amount` - the rotation to apply.
     ///   * `point` - the center of rotation.
     #[inline]
-    fn append_rotation_wrt_point_cpy(&self, amount: &AV, center: &LV) -> Self {
-        let mut res = Translation::append_translation_cpy(self, &-*center);
+    fn append_rotation_wrt_point(&self, amount: &AV, center: &LV) -> Self {
+        let mut res = Translation::append_translation(self, &-*center);
 
-        res.append_rotation(amount);
-        res.append_translation(center);
+        res.append_rotation_mut(amount);
+        res.append_translation_mut(center);
 
         res
     }
@@ -107,10 +107,10 @@ pub trait RotationWithTranslation<LV: Neg<Output = LV> + Copy, AV>: Rotation<AV>
     ///   * `amount` - the rotation to be applied
     ///   * `center` - the new center of rotation
     #[inline]
-    fn append_rotation_wrt_point(&mut self, amount: &AV, center: &LV) {
-        self.append_translation(&-*center);
-        self.append_rotation(amount);
-        self.append_translation(center);
+    fn append_rotation_wrt_point_mut(&mut self, amount: &AV, center: &LV) {
+        self.append_translation_mut(&-*center);
+        self.append_rotation_mut(amount);
+        self.append_translation_mut(center);
     }
 
     /// Applies a rotation centered on the translation of `m`.
@@ -119,8 +119,8 @@ pub trait RotationWithTranslation<LV: Neg<Output = LV> + Copy, AV>: Rotation<AV>
     ///   * `t` - the object to be rotated.
     ///   * `amount` - the rotation to apply.
     #[inline]
-    fn append_rotation_wrt_center_cpy(&self, amount: &AV) -> Self {
-        RotationWithTranslation::append_rotation_wrt_point_cpy(self, amount, &self.translation())
+    fn append_rotation_wrt_center(&self, amount: &AV) -> Self {
+        RotationWithTranslation::append_rotation_wrt_point(self, amount, &self.translation())
     }
 
     /// Applies a rotation centered on the translation of `m`.
@@ -130,9 +130,9 @@ pub trait RotationWithTranslation<LV: Neg<Output = LV> + Copy, AV>: Rotation<AV>
     /// # Arguments
     ///   * `amount` - the rotation to apply.
     #[inline]
-    fn append_rotation_wrt_center(&mut self, amount: &AV) {
+    fn append_rotation_wrt_center_mut(&mut self, amount: &AV) {
         let center = self.translation();
-        self.append_rotation_wrt_point(amount, &center)
+        self.append_rotation_wrt_point_mut(amount, &center)
     }
 }
 
@@ -173,16 +173,16 @@ pub trait Transformation<M> {
     fn inv_transformation(&self) -> M;
 
     /// Appends a transformation to this object.
-    fn append_transformation(&mut self, &M);
+    fn append_transformation_mut(&mut self, &M);
 
     /// Appends the transformation `amount` to a copy of `t`.
-    fn append_transformation_cpy(&self, amount: &M) -> Self;
+    fn append_transformation(&self, amount: &M) -> Self;
 
     /// Prepends a transformation to this object.
-    fn prepend_transformation(&mut self, &M);
+    fn prepend_transformation_mut(&mut self, &M);
 
     /// Prepends the transformation `amount` to a copy of `t`.
-    fn prepend_transformation_cpy(&self, amount: &M) -> Self;
+    fn prepend_transformation(&self, amount: &M) -> Self;
 
     /// Sets the transformation of `self`.
     fn set_transformation(&mut self, M);
@@ -220,10 +220,10 @@ pub trait Norm<N: BaseFloat> {
     fn sqnorm(&self) -> N;
 
     /// Gets the normalized version of a copy of `v`.
-    fn normalize_cpy(&self) -> Self;
+    fn normalize(&self) -> Self;
 
     /// Normalizes `self`.
-    fn normalize(&mut self) -> N;
+    fn normalize_mut(&mut self) -> N;
 }
 
 /**

--- a/src/traits/operations.rs
+++ b/src/traits/operations.rs
@@ -153,13 +153,13 @@ pub trait POrd {
 /// Trait for testing approximate equality
 pub trait ApproxEq<Eps>: Sized {
     /// Default epsilon for approximation.
-    fn approx_epsilon(unused_self: Option<Self>) -> Eps;
+    fn approx_epsilon(unused_mut: Option<Self>) -> Eps;
 
     /// Tests approximate equality using a custom epsilon.
     fn approx_eq_eps(&self, other: &Self, epsilon: &Eps) -> bool;
 
     /// Default ULPs for approximation.
-    fn approx_ulps(unused_self: Option<Self>) -> u32;
+    fn approx_ulps(unused_mut: Option<Self>) -> u32;
 
     /// Tests approximate equality using units in the last place (ULPs)
     fn approx_eq_ulps(&self, other: &Self, ulps: u32) -> bool;
@@ -278,10 +278,10 @@ pub trait Absolute<A> {
 /// Trait of objects having an inverse. Typically used to implement matrix inverse.
 pub trait Inv {
     /// Returns the inverse of `m`.
-    fn inv_cpy(&self) -> Option<Self>;
+    fn inv(&self) -> Option<Self>;
 
     /// In-place version of `inverse`.
-    fn inv(&mut self) -> bool;
+    fn inv_mut(&mut self) -> bool;
 }
 
 /// Trait of objects having a determinant. Typically used by square matrices.
@@ -293,10 +293,10 @@ pub trait Det<N> {
 /// Trait of objects which can be transposed.
 pub trait Transpose {
     /// Computes the transpose of a matrix.
-    fn transpose_cpy(&self) -> Self;
+    fn transpose(&self) -> Self;
 
     /// In-place version of `transposed`.
-    fn transpose(&mut self);
+    fn transpose_mut(&mut self);
 }
 
 /// Traits of objects having an outer product.

--- a/src/traits/structure.rs
+++ b/src/traits/structure.rs
@@ -161,7 +161,7 @@ pub trait RowSlice<R> {
 /// Trait of objects having a spacial dimension known at compile time.
 pub trait Dim {
     /// The dimension of the object.
-    fn dim(unused_self: Option<Self>) -> usize;
+    fn dim(unused_mut: Option<Self>) -> usize;
 }
 
 /// Trait to get the diagonal of square matrices.


### PR DESCRIPTION
Fixes #52.

This renames pairs of methods like `normalize_cpy`, `normalize` to `normalize`
and `normalize_mut`. Note that the previous in-place operations had the same
name that now belongs to the copy operations. Therefore this is a breaking
change.

On a similar note, the `Quat::conjugate` method was also renamed to
`conjugate_mut` and a new copying method has taken its place. This appears to
be a similar issue (apart from the lack of the copy operation) and thus was
dealt with here, too.