### PR TITLE
Add #[derive_Rand], dropping #[derive(Rand)]

### DIFF
--- a/src/structs/mat.rs
+++ b/src/structs/mat.rs
@@ -20,7 +20,8 @@ use quickcheck::{Arbitrary, Gen};
 
 
 /// Special identity matrix. All its operation are no-ops.
-#[derive(Eq, PartialEq, RustcDecodable, Clone, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcDecodable, Clone, Debug, Copy)]
+#[derive_Rand]
 pub struct Identity;
 
 impl Identity {
@@ -32,7 +33,8 @@ impl Identity {
 }
 
 /// Square matrix of dimension 1.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[derive_Rand]
 pub struct Mat1<N> {
     pub m11: N
 }
@@ -77,7 +79,8 @@ eigen_qr_impl!(Mat1, Vec1);
 arbitrary_impl!(Mat1, m11);
 
 /// Square matrix of dimension 2.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[derive_Rand]
 pub struct Mat2<N> {
     pub m11: N, pub m21: N,
     pub m12: N, pub m22: N
@@ -126,7 +129,8 @@ eigen_qr_impl!(Mat2, Vec2);
 arbitrary_impl!(Mat2, m11, m12, m21, m22);
 
 /// Square matrix of dimension 3.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[derive_Rand]
 pub struct Mat3<N> {
     pub m11: N, pub m21: N, pub m31: N,
     pub m12: N, pub m22: N, pub m32: N,
@@ -213,7 +217,8 @@ arbitrary_impl!(Mat3,
 );
 
 /// Square matrix of dimension 4.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[derive_Rand]
 pub struct Mat4<N> {
     pub m11: N, pub m21: N, pub m31: N, pub m41: N,
     pub m12: N, pub m22: N, pub m32: N, pub m42: N,
@@ -319,7 +324,8 @@ arbitrary_impl!(Mat4,
 );
 
 /// Square matrix of dimension 5.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[derive_Rand]
 pub struct Mat5<N> {
     pub m11: N, pub m21: N, pub m31: N, pub m41: N, pub m51: N,
     pub m12: N, pub m22: N, pub m32: N, pub m42: N, pub m52: N,
@@ -440,7 +446,8 @@ arbitrary_impl!(Mat5,
 );
 
 /// Square matrix of dimension 6.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[derive_Rand]
 pub struct Mat6<N> {
     pub m11: N, pub m21: N, pub m31: N, pub m41: N, pub m51: N, pub m61: N,
     pub m12: N, pub m22: N, pub m32: N, pub m42: N, pub m52: N, pub m62: N,

--- a/src/structs/pnt.rs
+++ b/src/structs/pnt.rs
@@ -17,7 +17,8 @@ use quickcheck::{Arbitrary, Gen};
 
 
 /// Point of dimension 0.
-#[derive(Eq, PartialEq, RustcDecodable, Clone, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcDecodable, Clone, Debug, Copy)]
+#[derive_Rand]
 pub struct Pnt0<N>;
 
 impl<N> Pnt0<N> {
@@ -35,7 +36,8 @@ impl<N> Pnt0<N> {
 }
 
 /// Point of dimension 1.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[derive_Rand]
 pub struct Pnt1<N> {
     /// First component of the point.
     pub x: N
@@ -74,7 +76,8 @@ num_float_pnt_impl!(Pnt1, Vec1);
 arbitrary_pnt_impl!(Pnt1, x);
 
 /// Point of dimension 2.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[derive_Rand]
 pub struct Pnt2<N> {
     /// First component of the point.
     pub x: N,
@@ -115,7 +118,8 @@ num_float_pnt_impl!(Pnt2, Vec2);
 arbitrary_pnt_impl!(Pnt2, x, y);
 
 /// Point of dimension 3.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[derive_Rand]
 pub struct Pnt3<N> {
     /// First component of the point.
     pub x: N,
@@ -158,7 +162,8 @@ num_float_pnt_impl!(Pnt3, Vec3);
 arbitrary_pnt_impl!(Pnt3, x, y, z);
 
 /// Point of dimension 4.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[derive_Rand]
 pub struct Pnt4<N> {
     /// First component of the point.
     pub x: N,
@@ -203,7 +208,8 @@ num_float_pnt_impl!(Pnt4, Vec4);
 arbitrary_pnt_impl!(Pnt4, x, y, z, w);
 
 /// Point of dimension 5.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[derive_Rand]
 pub struct Pnt5<N> {
     /// First component of the point.
     pub x: N,
@@ -250,7 +256,8 @@ num_float_pnt_impl!(Pnt5, Vec5);
 arbitrary_pnt_impl!(Pnt5, x, y, z, w, a);
 
 /// Point of dimension 6.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[derive_Rand]
 pub struct Pnt6<N> {
     /// First component of the point.
     pub x: N,

--- a/src/structs/quat.rs
+++ b/src/structs/quat.rs
@@ -20,7 +20,8 @@ use quickcheck::{Arbitrary, Gen};
 
 
 /// A quaternion.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[derive_Rand]
 pub struct Quat<N> {
     /// The scalar component of the quaternion.
     pub w: N,

--- a/src/structs/vec.rs
+++ b/src/structs/vec.rs
@@ -19,7 +19,8 @@ use quickcheck::{Arbitrary, Gen};
 
 
 /// Vector of dimension 0.
-#[derive(Eq, PartialEq, RustcDecodable, Clone, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcDecodable, Clone, Debug, Copy)]
+#[derive_Rand]
 pub struct Vec0<N>;
 
 impl<N> Vec0<N> {
@@ -37,7 +38,8 @@ impl<N> Vec0<N> {
 }
 
 /// Vector of dimension 1.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[derive_Rand]
 pub struct Vec1<N> {
     /// First component of the vector.
     pub x: N
@@ -87,7 +89,8 @@ absolute_vec_impl!(Vec1, x);
 arbitrary_impl!(Vec1, x);
 
 /// Vector of dimension 2.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[derive_Rand]
 pub struct Vec2<N> {
     /// First component of the vector.
     pub x: N,
@@ -139,7 +142,8 @@ absolute_vec_impl!(Vec2, x, y);
 arbitrary_impl!(Vec2, x, y);
 
 /// Vector of dimension 3.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[derive_Rand]
 pub struct Vec3<N> {
     /// First component of the vector.
     pub x: N,
@@ -194,7 +198,8 @@ arbitrary_impl!(Vec3, x, y, z);
 
 
 /// Vector of dimension 4.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[derive_Rand]
 pub struct Vec4<N> {
     /// First component of the vector.
     pub x: N,
@@ -250,7 +255,8 @@ absolute_vec_impl!(Vec4, x, y, z, w);
 arbitrary_impl!(Vec4, x, y, z, w);
 
 /// Vector of dimension 5.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[derive_Rand]
 pub struct Vec5<N> {
     /// First component of the vector.
     pub x: N,
@@ -308,7 +314,8 @@ absolute_vec_impl!(Vec5, x, y, z, w, a);
 arbitrary_impl!(Vec5, x, y, z, w, a);
 
 /// Vector of dimension 6.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[derive_Rand]
 pub struct Vec6<N> {
     /// First component of the vector.
     pub x: N,


### PR DESCRIPTION
`#[derive(Rand)]` has been deprecated. This PR will remove many compiler warnings.