### PR TITLE
`Output` is not a member of trait `IndexMut` anymore.

### DIFF
--- a/src/structs/dmat.rs
+++ b/src/structs/dmat.rs
@@ -278,8 +278,6 @@ impl<N> Index<(usize, usize)> for DMat<N> {
 }
 
 impl<N> IndexMut<(usize, usize)> for DMat<N> {
-    type Output = N;
-
     fn index_mut(&mut self, &(i, j): &(usize, usize)) -> &mut N {
         assert!(i < self.nrows);
         assert!(j < self.ncols);

--- a/src/structs/dvec_macros.rs
+++ b/src/structs/dvec_macros.rs
@@ -86,8 +86,6 @@ macro_rules! dvec_impl(
         }
 
         impl<N> IndexMut<usize> for $dvec<N> {
-            type Output = N;
-
             fn index_mut(&mut self, i: &usize) -> &mut N {
                 &mut self.as_mut_slice()[*i]
             }

--- a/src/structs/mat_macros.rs
+++ b/src/structs/mat_macros.rs
@@ -312,8 +312,6 @@ macro_rules! index_impl(
         }
 
         impl<N> IndexMut<(usize, usize)> for $t<N> {
-            type Output = N;
-
             fn index_mut(&mut self, &(i, j): &(usize, usize)) -> &mut N {
                 unsafe {
                     &mut mem::transmute::<&mut $t<N>, &mut [N; $dim * $dim]>(self)[i + j * $dim]

--- a/src/structs/spec/vec0.rs
+++ b/src/structs/spec/vec0.rs
@@ -30,8 +30,6 @@ impl<N> Index<usize> for vec::Vec0<N> {
 }
 
 impl<N> IndexMut<usize> for vec::Vec0<N> {
-    type Output = N;
-
     #[inline]
     fn index_mut(&mut self, _: &usize) -> &mut N {
         panic!("Canot index a Vec0.")

--- a/src/structs/vec_macros.rs
+++ b/src/structs/vec_macros.rs
@@ -234,8 +234,6 @@ macro_rules! index_impl(
         }
 
         impl<N> IndexMut<usize> for $t<N> {
-            type Output = N;
-
             fn index_mut(&mut self, i: &usize) -> &mut N {
                 &mut self.as_array_mut()[*i]
             }


### PR DESCRIPTION
`Output` is not a member of trait `IndexMut` anymore. This PR will fix compiler error for new rust nightly