### PR TITLE
Fix deprecated plugin syntax.

### DIFF
--- a/tests/assert.rs
+++ b/tests/assert.rs
@@ -1,8 +1,8 @@
 //! Assertion macro tests
 
 #![feature(plugin)]
+#![plugin(nalgebra)]
 
-#[plugin]
 #[macro_use]
 extern crate nalgebra;
 


### PR DESCRIPTION
This makes the test build with `rustc 1.0.0-nightly (b63cee4a1 2015-02-14 17:01:11 +0000)` for me.