### PR TITLE
Adapt to upstream changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ arbitrary = ["quickcheck"]
 
 [dependencies]
 rustc-serialize = "*"
+rand = "0.1"
 
 [dependencies.quickcheck]
 optional = true

--- a/benches/construction.rs
+++ b/benches/construction.rs
@@ -1,7 +1,8 @@
 extern crate test;
+extern crate rand;
 extern crate "nalgebra" as na;
 
-use std::rand::{IsaacRng, Rng};
+use rand::{IsaacRng, Rng};
 use test::Bencher;
 use na::{UnitQuat, Rot2, Rot3, Vec1, Vec3};
 

--- a/benches/dmat.rs
+++ b/benches/dmat.rs
@@ -1,3 +1,5 @@
+#![feature(test)]
+
 extern crate test;
 extern crate "nalgebra" as na;
 

--- a/benches/mat.rs
+++ b/benches/mat.rs
@@ -1,9 +1,10 @@
-#![feature(macro_rules)]
+#![feature(test)]
 
 extern crate test;
+extern crate rand;
 extern crate "nalgebra" as na;
 
-use std::rand::{IsaacRng, Rng};
+use rand::{IsaacRng, Rng};
 use test::Bencher;
 use na::{Vec2, Vec3, Vec4, Mat2, Mat3, Mat4};
 use std::ops::{Add, Sub, Mul, Div};

--- a/benches/quat.rs
+++ b/benches/quat.rs
@@ -1,9 +1,10 @@
-#![feature(macro_rules)]
+#![feature(test)]
 
 extern crate test;
+extern crate rand;
 extern crate "nalgebra" as na;
 
-use std::rand::{IsaacRng, Rng};
+use rand::{IsaacRng, Rng};
 use test::Bencher;
 use na::{Quat, UnitQuat, Vec3};
 use std::ops::{Add, Sub, Mul, Div};

--- a/benches/vec.rs
+++ b/benches/vec.rs
@@ -1,9 +1,10 @@
-#![feature(macro_rules)]
+#![feature(test)]
 
 extern crate test;
+extern crate rand;
 extern crate "nalgebra" as na;
 
-use std::rand::{IsaacRng, Rng};
+use rand::{IsaacRng, Rng};
 use test::Bencher;
 use na::{Vec2, Vec3, Vec4};
 use std::ops::{Add, Sub, Mul, Div};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,13 +83,13 @@ Feel free to add your project to this list if you happen to use **nalgebra**!
 #![deny(unused_results)]
 #![warn(missing_docs)]
 #![feature(unboxed_closures)]
-#![feature(rand)]
 #![feature(hash)]
 #![feature(core)]
 #![feature(std_misc)]
 #![doc(html_root_url = "http://nalgebra.org/doc")]
 
 extern crate "rustc-serialize" as rustc_serialize;
+extern crate rand;
 
 #[cfg(feature="arbitrary")]
 extern crate quickcheck;

--- a/src/structs/dmat.rs
+++ b/src/structs/dmat.rs
@@ -2,17 +2,14 @@
 
 #![allow(missing_docs)] // we hide doc to not have to document the $trhs double dispatch trait.
 
-use std::cmp;
+use std::{cmp, mem};
 use std::iter::repeat;
-use std::rand::Rand;
-use std::rand;
 use std::ops::{Add, Sub, Mul, Div, Index, IndexMut};
-use traits::operations::ApproxEq;
-use std::mem;
-use structs::dvec::DVec;
-use traits::operations::{Inv, Transpose, Mean, Cov};
-use traits::structure::{Cast, ColSlice, RowSlice, Diag, Eye, Indexable, Shape, Zero, One, BaseNum};
 use std::fmt::{Debug, Display, Formatter, Result};
+use rand::{self, Rand};
+use structs::dvec::DVec;
+use traits::operations::{ApproxEq, Inv, Transpose, Mean, Cov};
+use traits::structure::{Cast, ColSlice, RowSlice, Diag, Eye, Indexable, Shape, Zero, One, BaseNum};
 #[cfg(feature="arbitrary")]
 use quickcheck::{Arbitrary, Gen};
 

--- a/src/structs/dvec.rs
+++ b/src/structs/dvec.rs
@@ -68,14 +68,8 @@ impl<N> DVec<N> {
 
 impl<N> FromIterator<N> for DVec<N> {
     #[inline]
-    fn from_iter<I: Iterator<Item = N>>(mut param: I) -> DVec<N> {
-        let mut res = DVec { at: Vec::new() };
-
-        for e in param {
-            res.at.push(e)
-        }
-
-        res
+    fn from_iter<I: Iterator<Item = N>>(param: I) -> DVec<N> {
+        DVec { at: param.collect() }
     }
 }
 

--- a/src/structs/dvec.rs
+++ b/src/structs/dvec.rs
@@ -2,12 +2,11 @@
 
 #![allow(missing_docs)] // we hide doc to not have to document the $trhs double dispatch trait.
 
-use std::rand::Rand;
-use std::rand;
 use std::slice::{Iter, IterMut};
 use std::iter::FromIterator;
 use std::iter::repeat;
 use std::ops::{Add, Sub, Mul, Div, Neg, Index, IndexMut};
+use rand::{self, Rand};
 use traits::operations::{ApproxEq, Axpy};
 use traits::geometry::{Dot, Norm};
 use traits::structure::{Iterable, IterableMut, Indexable, Shape, BaseFloat, BaseNum, Zero, One};

--- a/src/structs/dvec_macros.rs
+++ b/src/structs/dvec_macros.rs
@@ -497,7 +497,7 @@ macro_rules! small_dvec_from_impl (
 
         impl<N: Zero> FromIterator<N> for $dvec<N> {
             #[inline]
-            fn from_iter<I: Iterator<Item = N>>(mut param: I) -> $dvec<N> {
+            fn from_iter<I: Iterator<Item = N>>(param: I) -> $dvec<N> {
                 let mut at: [N; $dim] = [ $( $zeros, )* ];
 
                 let mut dim = 0;

--- a/src/structs/iso.rs
+++ b/src/structs/iso.rs
@@ -4,7 +4,7 @@
 
 use std::ops::{Add, Sub, Mul};
 
-use std::rand::{Rand, Rng};
+use rand::{Rand, Rng};
 use structs::mat::{Mat3, Mat4, Mat5};
 use traits::structure::{Cast, Dim, Col, BaseFloat, BaseNum, One};
 use traits::operations::{Inv, ApproxEq};

--- a/src/structs/mat.rs
+++ b/src/structs/mat.rs
@@ -4,8 +4,9 @@
 
 use std::ops::{Add, Sub, Mul, Div, Index, IndexMut};
 use std::mem;
-use traits::operations::ApproxEq;
 use std::slice::{Iter, IterMut};
+use rand::{Rand, Rng};
+use traits::operations::ApproxEq;
 use structs::vec::{Vec1, Vec2, Vec3, Vec4, Vec5, Vec6};
 use structs::pnt::{Pnt1, Pnt4, Pnt5, Pnt6};
 use structs::dvec::{DVec1, DVec2, DVec3, DVec4, DVec5, DVec6};
@@ -20,7 +21,7 @@ use quickcheck::{Arbitrary, Gen};
 
 
 /// Special identity matrix. All its operation are no-ops.
-#[derive(Eq, PartialEq, RustcDecodable, Clone, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcDecodable, Clone, Debug, Copy)]
 pub struct Identity;
 
 impl Identity {
@@ -32,7 +33,7 @@ impl Identity {
 }
 
 /// Square matrix of dimension 1.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Mat1<N> {
     pub m11: N
 }
@@ -75,9 +76,10 @@ from_homogeneous_impl!(Mat1, Mat2, 1, 2);
 outer_impl!(Vec1, Mat1);
 eigen_qr_impl!(Mat1, Vec1);
 arbitrary_impl!(Mat1, m11);
+rand_impl!(Mat1, m11);
 
 /// Square matrix of dimension 2.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Mat2<N> {
     pub m11: N, pub m21: N,
     pub m12: N, pub m22: N
@@ -124,9 +126,10 @@ from_homogeneous_impl!(Mat2, Mat3, 2, 3);
 outer_impl!(Vec2, Mat2);
 eigen_qr_impl!(Mat2, Vec2);
 arbitrary_impl!(Mat2, m11, m12, m21, m22);
+rand_impl!(Mat2, m11, m12, m21, m22);
 
 /// Square matrix of dimension 3.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Mat3<N> {
     pub m11: N, pub m21: N, pub m31: N,
     pub m12: N, pub m22: N, pub m32: N,
@@ -211,9 +214,14 @@ arbitrary_impl!(Mat3,
     m21, m22, m23,
     m31, m32, m33
 );
+rand_impl!(Mat3,
+    m11, m12, m13,
+    m21, m22, m23,
+    m31, m32, m33
+);
 
 /// Square matrix of dimension 4.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Mat4<N> {
     pub m11: N, pub m21: N, pub m31: N, pub m41: N,
     pub m12: N, pub m22: N, pub m32: N, pub m42: N,
@@ -317,9 +325,15 @@ arbitrary_impl!(Mat4,
   m31, m32, m33, m34,
   m41, m42, m43, m44
 );
+rand_impl!(Mat4,
+  m11, m12, m13, m14,
+  m21, m22, m23, m24,
+  m31, m32, m33, m34,
+  m41, m42, m43, m44
+);
 
 /// Square matrix of dimension 5.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Mat5<N> {
     pub m11: N, pub m21: N, pub m31: N, pub m41: N, pub m51: N,
     pub m12: N, pub m22: N, pub m32: N, pub m42: N, pub m52: N,
@@ -438,9 +452,16 @@ arbitrary_impl!(Mat5,
   m41, m42, m43, m44, m45,
   m51, m52, m53, m54, m55
 );
+rand_impl!(Mat5,
+  m11, m12, m13, m14, m15,
+  m21, m22, m23, m24, m25,
+  m31, m32, m33, m34, m35,
+  m41, m42, m43, m44, m45,
+  m51, m52, m53, m54, m55
+);
 
 /// Square matrix of dimension 6.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Mat6<N> {
     pub m11: N, pub m21: N, pub m31: N, pub m41: N, pub m51: N, pub m61: N,
     pub m12: N, pub m22: N, pub m32: N, pub m42: N, pub m52: N, pub m62: N,
@@ -555,6 +576,14 @@ diag_impl!(Mat6, Vec6, 6);
 outer_impl!(Vec6, Mat6);
 eigen_qr_impl!(Mat6, Vec6);
 arbitrary_impl!(Mat6,
+  m11, m12, m13, m14, m15, m16,
+  m21, m22, m23, m24, m25, m26,
+  m31, m32, m33, m34, m35, m36,
+  m41, m42, m43, m44, m45, m46,
+  m51, m52, m53, m54, m55, m56,
+  m61, m62, m63, m64, m65, m66
+);
+rand_impl!(Mat6,
   m11, m12, m13, m14, m15, m16,
   m21, m22, m23, m24, m25, m26,
   m31, m32, m33, m34, m35, m36,

--- a/src/structs/pnt.rs
+++ b/src/structs/pnt.rs
@@ -6,6 +6,7 @@ use std::mem;
 use std::slice::{Iter, IterMut};
 use std::iter::{Iterator, FromIterator};
 use std::ops::{Add, Sub, Mul, Div, Neg, Index, IndexMut};
+use rand::{Rand, Rng};
 use traits::operations::{ApproxEq, POrd, POrdering, Axpy, ScalarAdd, ScalarSub, ScalarMul,
                          ScalarDiv};
 use traits::structure::{Cast, Dim, Indexable, Iterable, IterableMut, PntAsVec, Shape,
@@ -17,7 +18,7 @@ use quickcheck::{Arbitrary, Gen};
 
 
 /// Point of dimension 0.
-#[derive(Eq, PartialEq, RustcDecodable, Clone, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcDecodable, Clone, Debug, Copy)]
 pub struct Pnt0<N>;
 
 impl<N> Pnt0<N> {
@@ -35,7 +36,7 @@ impl<N> Pnt0<N> {
 }
 
 /// Point of dimension 1.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Pnt1<N> {
     /// First component of the point.
     pub x: N
@@ -72,9 +73,10 @@ pnt_to_homogeneous_impl!(Pnt1, Pnt2, y, x);
 pnt_from_homogeneous_impl!(Pnt1, Pnt2, y, x);
 num_float_pnt_impl!(Pnt1, Vec1);
 arbitrary_pnt_impl!(Pnt1, x);
+rand_impl!(Pnt1, x);
 
 /// Point of dimension 2.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Pnt2<N> {
     /// First component of the point.
     pub x: N,
@@ -113,9 +115,10 @@ pnt_to_homogeneous_impl!(Pnt2, Pnt3, z, x, y);
 pnt_from_homogeneous_impl!(Pnt2, Pnt3, z, x, y);
 num_float_pnt_impl!(Pnt2, Vec2);
 arbitrary_pnt_impl!(Pnt2, x, y);
+rand_impl!(Pnt2, x, y);
 
 /// Point of dimension 3.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Pnt3<N> {
     /// First component of the point.
     pub x: N,
@@ -156,9 +159,10 @@ pnt_to_homogeneous_impl!(Pnt3, Pnt4, w, x, y, z);
 pnt_from_homogeneous_impl!(Pnt3, Pnt4, w, x, y, z);
 num_float_pnt_impl!(Pnt3, Vec3);
 arbitrary_pnt_impl!(Pnt3, x, y, z);
+rand_impl!(Pnt3, x, y, z);
 
 /// Point of dimension 4.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Pnt4<N> {
     /// First component of the point.
     pub x: N,
@@ -201,9 +205,10 @@ pnt_to_homogeneous_impl!(Pnt4, Pnt5, a, x, y, z, w);
 pnt_from_homogeneous_impl!(Pnt4, Pnt5, a, x, y, z, w);
 num_float_pnt_impl!(Pnt4, Vec4);
 arbitrary_pnt_impl!(Pnt4, x, y, z, w);
+rand_impl!(Pnt4, x, y, z, w);
 
 /// Point of dimension 5.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Pnt5<N> {
     /// First component of the point.
     pub x: N,
@@ -248,9 +253,10 @@ pnt_to_homogeneous_impl!(Pnt5, Pnt6, b, x, y, z, w, a);
 pnt_from_homogeneous_impl!(Pnt5, Pnt6, b, x, y, z, w, a);
 num_float_pnt_impl!(Pnt5, Vec5);
 arbitrary_pnt_impl!(Pnt5, x, y, z, w, a);
+rand_impl!(Pnt5, x, y, z, w, a);
 
 /// Point of dimension 6.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Pnt6<N> {
     /// First component of the point.
     pub x: N,
@@ -295,3 +301,4 @@ iterable_impl!(Pnt6, 6);
 iterable_mut_impl!(Pnt6, 6);
 num_float_pnt_impl!(Pnt6, Vec6);
 arbitrary_pnt_impl!(Pnt6, x, y, z, w, a, b);
+rand_impl!(Pnt6, x, y, z, w, a, b);

--- a/src/structs/quat.rs
+++ b/src/structs/quat.rs
@@ -4,10 +4,10 @@
 
 use std::mem;
 use std::num;
-use std::rand::{Rand, Rng};
 use std::slice::{Iter, IterMut};
 use std::ops::{Add, Sub, Mul, Div, Neg, Index, IndexMut};
 use std::iter::FromIterator;
+use rand::{Rand, Rng};
 use structs::{Vec3, Pnt3, Rot3, Mat3};
 use traits::operations::{ApproxEq, Inv, POrd, POrdering, Axpy, ScalarAdd, ScalarSub, ScalarMul,
                          ScalarDiv};
@@ -20,7 +20,7 @@ use quickcheck::{Arbitrary, Gen};
 
 
 /// A quaternion.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Quat<N> {
     /// The scalar component of the quaternion.
     pub w: N,
@@ -249,6 +249,9 @@ impl<N: BaseFloat> UnitQuat<N> {
         }
     }
 }
+
+rand_impl!(Quat, w, i, j, k);
+
 
 impl<N> UnitQuat<N> {
     /// Creates a new unit quaternion from a quaternion.

--- a/src/structs/quat.rs
+++ b/src/structs/quat.rs
@@ -195,12 +195,7 @@ impl<N: BaseFloat> UnitQuat<N> {
     /// The input quaternion will be normalized.
     #[inline]
     pub fn new_with_quat(q: Quat<N>) -> UnitQuat<N> {
-        let mut q = q;
-        let _ = q.normalize();
-
-        UnitQuat {
-            q: q
-        }
+        UnitQuat { q: q.normalize() }
     }
 
     /// Creates a new unit quaternion from Euler angles.

--- a/src/structs/rot.rs
+++ b/src/structs/rot.rs
@@ -3,7 +3,7 @@
 #![allow(missing_docs)]
 
 use std::ops::{Mul, Neg, Index};
-use std::rand::{Rand, Rng};
+use rand::{Rand, Rng};
 use traits::geometry::{Rotate, Rotation, AbsoluteRotate, RotationMatrix, Transform, ToHomogeneous,
                        Norm, Cross};
 use traits::structure::{Cast, Dim, Row, Col, BaseFloat, BaseNum, Zero, One};

--- a/src/structs/spec/vec0.rs
+++ b/src/structs/spec/vec0.rs
@@ -2,6 +2,7 @@ use std::ops::{Add, Sub, Mul, Div, Neg, Index, IndexMut};
 use std::mem;
 use std::slice::{Iter, IterMut};
 use std::iter::{Iterator, FromIterator};
+use rand::{Rand, Rng};
 use traits::operations::ApproxEq;
 use traits::structure::{Iterable, IterableMut, Indexable, Basis, Dim, Shape, BaseFloat, BaseNum,
                         Zero, One, Bounded};
@@ -256,4 +257,9 @@ impl<N: Bounded> Bounded for vec::Vec0<N> {
     fn min_value() -> vec::Vec0<N> {
         vec::Vec0
     }
+}
+
+impl<N> Rand for vec::Vec0<N> {
+    #[inline]
+    fn rand<R: Rng>(_: &mut R) -> vec::Vec0<N> { vec::Vec0 }
 }

--- a/src/structs/vec.rs
+++ b/src/structs/vec.rs
@@ -6,6 +6,7 @@ use std::ops::{Add, Sub, Mul, Div, Neg, Index, IndexMut};
 use std::mem;
 use std::slice::{Iter, IterMut};
 use std::iter::{Iterator, FromIterator};
+use rand::{Rand, Rng};
 use traits::operations::{ApproxEq, POrd, POrdering, Axpy, ScalarAdd, ScalarSub, ScalarMul,
                          ScalarDiv, Absolute};
 use traits::geometry::{Transform, Rotate, FromHomogeneous, ToHomogeneous, Dot, Norm,
@@ -19,7 +20,7 @@ use quickcheck::{Arbitrary, Gen};
 
 
 /// Vector of dimension 0.
-#[derive(Eq, PartialEq, RustcDecodable, Clone, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcDecodable, Clone, Debug, Copy)]
 pub struct Vec0<N>;
 
 impl<N> Vec0<N> {
@@ -37,7 +38,7 @@ impl<N> Vec0<N> {
 }
 
 /// Vector of dimension 1.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Vec1<N> {
     /// First component of the vector.
     pub x: N
@@ -85,9 +86,10 @@ vec_as_pnt_impl!(Vec1, Pnt1, x);
 num_float_vec_impl!(Vec1);
 absolute_vec_impl!(Vec1, x);
 arbitrary_impl!(Vec1, x);
+rand_impl!(Vec1, x);
 
 /// Vector of dimension 2.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Vec2<N> {
     /// First component of the vector.
     pub x: N,
@@ -137,9 +139,10 @@ vec_as_pnt_impl!(Vec2, Pnt2, x, y);
 num_float_vec_impl!(Vec2);
 absolute_vec_impl!(Vec2, x, y);
 arbitrary_impl!(Vec2, x, y);
+rand_impl!(Vec2, x, y);
 
 /// Vector of dimension 3.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Vec3<N> {
     /// First component of the vector.
     pub x: N,
@@ -191,10 +194,11 @@ vec_as_pnt_impl!(Vec3, Pnt3, x, y, z);
 num_float_vec_impl!(Vec3);
 absolute_vec_impl!(Vec3, x, y, z);
 arbitrary_impl!(Vec3, x, y, z);
+rand_impl!(Vec3, x, y, z);
 
 
 /// Vector of dimension 4.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Vec4<N> {
     /// First component of the vector.
     pub x: N,
@@ -248,9 +252,10 @@ vec_as_pnt_impl!(Vec4, Pnt4, x, y, z, w);
 num_float_vec_impl!(Vec4);
 absolute_vec_impl!(Vec4, x, y, z, w);
 arbitrary_impl!(Vec4, x, y, z, w);
+rand_impl!(Vec4, x, y, z, w);
 
 /// Vector of dimension 5.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Vec5<N> {
     /// First component of the vector.
     pub x: N,
@@ -306,9 +311,10 @@ vec_as_pnt_impl!(Vec5, Pnt5, x, y, z, w, a);
 num_float_vec_impl!(Vec5);
 absolute_vec_impl!(Vec5, x, y, z, w, a);
 arbitrary_impl!(Vec5, x, y, z, w, a);
+rand_impl!(Vec5, x, y, z, w, a);
 
 /// Vector of dimension 6.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Rand, Debug, Copy)]
+#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Vec6<N> {
     /// First component of the vector.
     pub x: N,
@@ -364,3 +370,4 @@ vec_as_pnt_impl!(Vec6, Pnt6, x, y, z, w, a, b);
 num_float_vec_impl!(Vec6);
 absolute_vec_impl!(Vec6, x, y, z, w, a, b);
 arbitrary_impl!(Vec6, x, y, z, w, a, b);
+rand_impl!(Vec6, x, y, z, w, a, b);

--- a/src/structs/vec_macros.rs
+++ b/src/structs/vec_macros.rs
@@ -854,3 +854,14 @@ macro_rules! arbitrary_impl(
         }
     )
 );
+
+macro_rules! rand_impl(
+    ($t: ident, $($compN: ident),*) => (
+        impl<N: Rand> Rand for $t<N> {
+            #[inline]
+            fn rand<R: Rng>(rng: &mut R) -> $t<N> {
+                $t { $($compN: Rand::rand(rng), )* }
+            }
+        }
+    )
+);

--- a/tests/arbitrary.rs
+++ b/tests/arbitrary.rs
@@ -2,8 +2,8 @@
 
 extern crate "nalgebra" as na;
 extern crate quickcheck;
+extern crate rand;
 
-use std::rand;
 use quickcheck::{Arbitrary, StdGen};
 use na::*;
 

--- a/tests/assert.rs
+++ b/tests/assert.rs
@@ -1,8 +1,5 @@
 //! Assertion macro tests
 
-#![feature(plugin)]
-
-#[plugin]
 #[macro_use]
 extern crate nalgebra;
 

--- a/tests/mat.rs
+++ b/tests/mat.rs
@@ -1,6 +1,7 @@
 extern crate "nalgebra" as na;
+extern crate rand;
 
-use std::rand::random;
+use rand::random;
 use na::{Vec1, Vec3, Mat1, Mat2, Mat3, Mat4, Mat5, Mat6, Rot3, Persp3, PerspMat3, Ortho3, OrthoMat3,
          DMat, DVec, Row, Col, BaseFloat};
 

--- a/tests/quat.rs
+++ b/tests/quat.rs
@@ -1,7 +1,8 @@
 extern crate "nalgebra" as na;
+extern crate rand;
 
 use na::{Pnt3, Vec3, Rot3, UnitQuat, Rotation};
-use std::rand::random;
+use rand::random;
 
 #[test]
 fn test_quat_as_mat() {

--- a/tests/vec.rs
+++ b/tests/vec.rs
@@ -1,6 +1,7 @@
 extern crate "nalgebra" as na;
+extern crate rand;
 
-use std::rand::random;
+use rand::random;
 use na::{Vec0, Vec1, Vec2, Vec3, Vec4, Vec5, Vec6, Mat3, Iterable, IterableMut};
 
 macro_rules! test_iterator_impl(


### PR DESCRIPTION
Most importantly, the rand module has been removed from the standard library. With this change, `nalgebra` now depends on the [new crates.io module](https://crates.io/crates/rand).

Apart from that all warnings were cleared out, leading to the discovery of a bug in `UnitQuat::new_with_quat`, which has been fixed.