### PR TITLE
Nightly fixes, add repr(C)

### DIFF
--- a/src/structs/dmat.rs
+++ b/src/structs/dmat.rs
@@ -618,13 +618,13 @@ impl<N: ApproxEq<N>> ApproxEq<N> for DMat<N> {
 
     #[inline]
     fn approx_eq_eps(&self, other: &DMat<N>, epsilon: &N) -> bool {
-        let zip = self.mij.iter().zip(other.mij.iter());
+        let mut zip = self.mij.iter().zip(other.mij.iter());
         zip.all(|(a, b)| ApproxEq::approx_eq_eps(a, b, epsilon))
     }
 
     #[inline]
     fn approx_eq_ulps(&self, other: &DMat<N>, ulps: u32) -> bool {
-        let zip = self.mij.iter().zip(other.mij.iter());
+        let mut zip = self.mij.iter().zip(other.mij.iter());
         zip.all(|(a, b)| ApproxEq::approx_eq_ulps(a, b, ulps))
     }
 }

--- a/src/structs/dvec_macros.rs
+++ b/src/structs/dvec_macros.rs
@@ -319,13 +319,13 @@ macro_rules! dvec_impl(
 
             #[inline]
             fn approx_eq_eps(&self, other: &$dvec<N>, epsilon: &N) -> bool {
-                let zip = self.as_slice().iter().zip(other.as_slice().iter());
+                let mut zip = self.as_slice().iter().zip(other.as_slice().iter());
                 zip.all(|(a, b)| ApproxEq::approx_eq_eps(a, b, epsilon))
             }
 
             #[inline]
             fn approx_eq_ulps(&self, other: &$dvec<N>, ulps: u32) -> bool {
-                let zip = self.as_slice().iter().zip(other.as_slice().iter());
+                let mut zip = self.as_slice().iter().zip(other.as_slice().iter());
                 zip.all(|(a, b)| ApproxEq::approx_eq_ulps(a, b, ulps))
             }
         }

--- a/src/structs/mat.rs
+++ b/src/structs/mat.rs
@@ -21,6 +21,7 @@ use quickcheck::{Arbitrary, Gen};
 
 
 /// Special identity matrix. All its operation are no-ops.
+#[repr(C)]
 #[derive(Eq, PartialEq, RustcDecodable, Clone, Debug, Copy)]
 pub struct Identity;
 
@@ -33,6 +34,7 @@ impl Identity {
 }
 
 /// Square matrix of dimension 1.
+#[repr(C)]
 #[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Mat1<N> {
     pub m11: N
@@ -79,6 +81,7 @@ arbitrary_impl!(Mat1, m11);
 rand_impl!(Mat1, m11);
 
 /// Square matrix of dimension 2.
+#[repr(C)]
 #[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Mat2<N> {
     pub m11: N, pub m21: N,
@@ -129,6 +132,7 @@ arbitrary_impl!(Mat2, m11, m12, m21, m22);
 rand_impl!(Mat2, m11, m12, m21, m22);
 
 /// Square matrix of dimension 3.
+#[repr(C)]
 #[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Mat3<N> {
     pub m11: N, pub m21: N, pub m31: N,
@@ -221,6 +225,7 @@ rand_impl!(Mat3,
 );
 
 /// Square matrix of dimension 4.
+#[repr(C)]
 #[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Mat4<N> {
     pub m11: N, pub m21: N, pub m31: N, pub m41: N,
@@ -333,6 +338,7 @@ rand_impl!(Mat4,
 );
 
 /// Square matrix of dimension 5.
+#[repr(C)]
 #[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Mat5<N> {
     pub m11: N, pub m21: N, pub m31: N, pub m41: N, pub m51: N,
@@ -461,6 +467,7 @@ rand_impl!(Mat5,
 );
 
 /// Square matrix of dimension 6.
+#[repr(C)]
 #[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Mat6<N> {
     pub m11: N, pub m21: N, pub m31: N, pub m41: N, pub m51: N, pub m61: N,

--- a/src/structs/mat_macros.rs
+++ b/src/structs/mat_macros.rs
@@ -646,13 +646,13 @@ macro_rules! approx_eq_impl(
 
         #[inline]
         fn approx_eq_eps(&self, other: &$t<N>, epsilon: &N) -> bool {
-            let zip = self.iter().zip(other.iter());
+            let mut zip = self.iter().zip(other.iter());
             zip.all(|(a, b)| ApproxEq::approx_eq_eps(a, b, epsilon))
         }
 
         #[inline]
         fn approx_eq_ulps(&self, other: &$t<N>, ulps: u32) -> bool {
-            let zip = self.iter().zip(other.iter());
+            let mut zip = self.iter().zip(other.iter());
             zip.all(|(a, b)| ApproxEq::approx_eq_ulps(a, b, ulps))
         }
     }

--- a/src/structs/pnt.rs
+++ b/src/structs/pnt.rs
@@ -19,6 +19,7 @@ use quickcheck::{Arbitrary, Gen};
 
 
 /// Point of dimension 0.
+#[repr(C)]
 #[derive(Eq, PartialEq, Clone, Debug, Copy)]
 pub struct Pnt0<N>(pub PhantomData<N>);
 
@@ -37,6 +38,7 @@ impl<N> Pnt0<N> {
 }
 
 /// Point of dimension 1.
+#[repr(C)]
 #[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Pnt1<N> {
     /// First component of the point.
@@ -77,6 +79,7 @@ arbitrary_pnt_impl!(Pnt1, x);
 rand_impl!(Pnt1, x);
 
 /// Point of dimension 2.
+#[repr(C)]
 #[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Pnt2<N> {
     /// First component of the point.
@@ -119,6 +122,7 @@ arbitrary_pnt_impl!(Pnt2, x, y);
 rand_impl!(Pnt2, x, y);
 
 /// Point of dimension 3.
+#[repr(C)]
 #[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Pnt3<N> {
     /// First component of the point.
@@ -163,6 +167,7 @@ arbitrary_pnt_impl!(Pnt3, x, y, z);
 rand_impl!(Pnt3, x, y, z);
 
 /// Point of dimension 4.
+#[repr(C)]
 #[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Pnt4<N> {
     /// First component of the point.
@@ -209,6 +214,7 @@ arbitrary_pnt_impl!(Pnt4, x, y, z, w);
 rand_impl!(Pnt4, x, y, z, w);
 
 /// Point of dimension 5.
+#[repr(C)]
 #[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Pnt5<N> {
     /// First component of the point.
@@ -257,6 +263,7 @@ arbitrary_pnt_impl!(Pnt5, x, y, z, w, a);
 rand_impl!(Pnt5, x, y, z, w, a);
 
 /// Point of dimension 6.
+#[repr(C)]
 #[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Pnt6<N> {
     /// First component of the point.

--- a/src/structs/quat.rs
+++ b/src/structs/quat.rs
@@ -20,6 +20,7 @@ use quickcheck::{Arbitrary, Gen};
 
 
 /// A quaternion.
+#[repr(C)]
 #[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Quat<N> {
     /// The scalar component of the quaternion.
@@ -158,6 +159,7 @@ impl<N: ApproxEq<N> + BaseFloat> Div<Quat<N>> for Quat<N> {
 
 
 /// A unit quaternion that can represent a 3D rotation.
+#[repr(C)]
 #[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct UnitQuat<N> {
     q: Quat<N>

--- a/src/structs/vec.rs
+++ b/src/structs/vec.rs
@@ -21,6 +21,7 @@ use quickcheck::{Arbitrary, Gen};
 
 
 /// Vector of dimension 0.
+#[repr(C)]
 #[derive(Eq, PartialEq, Clone, Debug, Copy)]
 pub struct Vec0<N>(pub PhantomData<N>);
 
@@ -39,6 +40,7 @@ impl<N> Vec0<N> {
 }
 
 /// Vector of dimension 1.
+#[repr(C)]
 #[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Vec1<N> {
     /// First component of the vector.
@@ -90,6 +92,7 @@ arbitrary_impl!(Vec1, x);
 rand_impl!(Vec1, x);
 
 /// Vector of dimension 2.
+#[repr(C)]
 #[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Vec2<N> {
     /// First component of the vector.
@@ -143,6 +146,7 @@ arbitrary_impl!(Vec2, x, y);
 rand_impl!(Vec2, x, y);
 
 /// Vector of dimension 3.
+#[repr(C)]
 #[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Vec3<N> {
     /// First component of the vector.
@@ -199,6 +203,7 @@ rand_impl!(Vec3, x, y, z);
 
 
 /// Vector of dimension 4.
+#[repr(C)]
 #[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Vec4<N> {
     /// First component of the vector.
@@ -256,6 +261,7 @@ arbitrary_impl!(Vec4, x, y, z, w);
 rand_impl!(Vec4, x, y, z, w);
 
 /// Vector of dimension 5.
+#[repr(C)]
 #[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Vec5<N> {
     /// First component of the vector.
@@ -315,6 +321,7 @@ arbitrary_impl!(Vec5, x, y, z, w, a);
 rand_impl!(Vec5, x, y, z, w, a);
 
 /// Vector of dimension 6.
+#[repr(C)]
 #[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
 pub struct Vec6<N> {
     /// First component of the vector.

--- a/tests/mat.rs
+++ b/tests/mat.rs
@@ -7,7 +7,7 @@ use na::{Vec1, Vec3, Mat1, Mat2, Mat3, Mat4, Mat5, Mat6, Rot3, Persp3, PerspMat3
 
 macro_rules! test_inv_mat_impl(
   ($t: ty) => (
-    for _ in (0us .. 10000) {
+    for _ in (0usize .. 10000) {
       let randmat : $t = random();
 
       match na::inv(&randmat) {
@@ -20,7 +20,7 @@ macro_rules! test_inv_mat_impl(
 
 macro_rules! test_transpose_mat_impl(
   ($t: ty) => (
-    for _ in (0us .. 10000) {
+    for _ in (0usize .. 10000) {
       let randmat : $t = random();
 
       assert!(na::transpose(&na::transpose(&randmat)) == randmat);
@@ -30,7 +30,7 @@ macro_rules! test_transpose_mat_impl(
 
 macro_rules! test_qr_impl(
   ($t: ty) => (
-    for _ in (0us .. 10000) {
+    for _ in (0usize .. 10000) {
       let randmat : $t = random();
 
       let (q, r) = na::qr(&randmat);
@@ -44,7 +44,7 @@ macro_rules! test_qr_impl(
 // NOTE: deactivated untile we get a better convergence rate.
 // macro_rules! test_eigen_qr_impl(
 //     ($t: ty) => {
-//         for _ in (0us .. 10000) {
+//         for _ in (0usize .. 10000) {
 //             let randmat : $t = random();
 //             // Make it symetric so that we can recompose the matrix to test at the end.
 //             let randmat = na::transpose(&randmat) * randmat;
@@ -126,7 +126,7 @@ fn test_inv_mat6() {
 
 #[test]
 fn test_rotation2() {
-    for _ in (0us .. 10000) {
+    for _ in (0usize .. 10000) {
         let randmat: na::Rot2<f64> = na::one();
         let ang    = Vec1::new(na::abs(&random::<f64>()) % <f64 as BaseFloat>::pi());
 
@@ -143,7 +143,7 @@ fn test_index_mat2() {
 
 #[test]
 fn test_inv_rotation3() {
-    for _ in (0us .. 10000) {
+    for _ in (0usize .. 10000) {
         let randmat: Rot3<f64> = na::one();
         let dir:     Vec3<f64> = random();
         let ang            = na::normalize(&dir) * (na::abs(&random::<f64>()) % <f64 as BaseFloat>::pi());
@@ -251,7 +251,7 @@ fn test_dmat_from_vec() {
 /* FIXME: review qr decomposition to make it work with DMat.
 #[test]
 fn test_qr() {
-    for _ in (0us .. 10) {
+    for _ in (0usize .. 10) {
         let dim1: usize = random();
         let dim2: usize = random();
         let rows = min(40, max(dim1, dim2));

--- a/tests/quat.rs
+++ b/tests/quat.rs
@@ -6,7 +6,7 @@ use rand::random;
 
 #[test]
 fn test_quat_as_mat() {
-    for _ in (0us .. 10000) {
+    for _ in (0usize .. 10000) {
         let axis_angle: Vec3<f64> = random();
 
         assert!(na::approx_eq(&UnitQuat::new(axis_angle).to_rot(), &Rot3::new(axis_angle)))
@@ -15,7 +15,7 @@ fn test_quat_as_mat() {
 
 #[test]
 fn test_quat_mul_vec_or_pnt_as_mat() {
-    for _ in (0us .. 10000) {
+    for _ in (0usize .. 10000) {
         let axis_angle: Vec3<f64> = random();
         let vec: Vec3<f64> = random();
         let pnt: Pnt3<f64> = random();
@@ -32,7 +32,7 @@ fn test_quat_mul_vec_or_pnt_as_mat() {
 
 #[test]
 fn test_quat_div_quat() {
-    for _ in (0us .. 10000) {
+    for _ in (0usize .. 10000) {
         let axis_angle1: Vec3<f64> = random();
         let axis_angle2: Vec3<f64> = random();
 
@@ -48,7 +48,7 @@ fn test_quat_div_quat() {
 
 #[test]
 fn test_quat_to_axis_angle() {
-    for _ in (0us .. 10000) {
+    for _ in (0usize .. 10000) {
         let axis_angle: Vec3<f64> = random();
 
         let q = UnitQuat::new(axis_angle);
@@ -60,7 +60,7 @@ fn test_quat_to_axis_angle() {
 
 #[test]
 fn test_quat_euler_angles() {
-    for _ in (0us .. 10000) {
+    for _ in (0usize .. 10000) {
         let angles: Vec3<f64> = random();
 
         let q = UnitQuat::new_with_euler_angles(angles.x, angles.y, angles.z);

--- a/tests/vec.rs
+++ b/tests/vec.rs
@@ -6,7 +6,7 @@ use na::{Vec0, Vec1, Vec2, Vec3, Vec4, Vec5, Vec6, Mat3, Iterable, IterableMut};
 
 macro_rules! test_iterator_impl(
     ($t: ty, $n: ty) => (
-        for _ in (0us .. 10000) {
+        for _ in (0usize .. 10000) {
             let v: $t      = random();
             let mut mv: $t = v.clone();
             let n: $n      = random();
@@ -24,7 +24,7 @@ macro_rules! test_iterator_impl(
 
 macro_rules! test_commut_dot_impl(
     ($t: ty) => (
-        for _ in (0us .. 10000) {
+        for _ in (0usize .. 10000) {
             let v1 : $t = random();
             let v2 : $t = random();
 
@@ -35,7 +35,7 @@ macro_rules! test_commut_dot_impl(
 
 macro_rules! test_scalar_op_impl(
     ($t: ty, $n: ty) => (
-        for _ in (0us .. 10000) {
+        for _ in (0usize .. 10000) {
             let v1 : $t = random();
             let n  : $n = random();
 
@@ -58,7 +58,7 @@ macro_rules! test_scalar_op_impl(
 
 macro_rules! test_basis_impl(
     ($t: ty) => (
-        for _ in (0us .. 10000) {
+        for _ in (0usize .. 10000) {
             na::canonical_basis(|e1: $t| {
                 na::canonical_basis(|e2: $t| {
                     assert!(e1 == e2 || na::approx_eq(&na::dot(&e1, &e2), &na::zero()));
@@ -76,7 +76,7 @@ macro_rules! test_basis_impl(
 
 macro_rules! test_subspace_basis_impl(
     ($t: ty) => (
-        for _ in (0us .. 10000) {
+        for _ in (0usize .. 10000) {
             let v : $t = random();
             let v1     = na::normalize(&v);
 
@@ -100,7 +100,7 @@ macro_rules! test_subspace_basis_impl(
 
 #[test]
 fn test_cross_vec3() {
-    for _ in (0us .. 10000) {
+    for _ in (0usize .. 10000) {
         let v1 : Vec3<f64> = random();
         let v2 : Vec3<f64> = random();
         let v3 : Vec3<f64> = na::cross(&v1, &v2);


### PR DESCRIPTION
Minor fix to macros that use `all`.
Changes deprecated suffixes in tests from `us` to `usize`.
Adds `#[repr(C)]` to structs that are most likely to be used in FFI scenarios (fixed size vectors, points, quats, and mats). It's unlikely that the compiler would reorder the fields when they all have the same size, but it doesn't hurt to be explicit.