### PR TITLE
Add type annotation required by rustc 2015-03-31

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -541,7 +541,7 @@ pub fn prepend_rotation<V, M: Rotation<V>>(m: &M, v: &V) -> M {
 /// use na::{BaseFloat, Rot3, Vec3};
 ///
 /// fn main() {
-///     let t  = Rot3::new(Vec3::new(0.0f64, 0.0, 0.5 * BaseFloat::pi()));
+///     let t  = Rot3::new(Vec3::new(0.0f64, 0.0, 0.5 * <f64 as BaseFloat>::pi()));
 ///     let v  = Vec3::new(1.0, 0.0, 0.0);
 ///
 ///     let tv = na::rotate(&t, &v);
@@ -562,7 +562,7 @@ pub fn rotate<V, M: Rotate<V>>(m: &M, v: &V) -> V {
 /// use na::{BaseFloat, Rot3, Vec3};
 ///
 /// fn main() {
-///     let t  = Rot3::new(Vec3::new(0.0f64, 0.0, 0.5 * BaseFloat::pi()));
+///     let t  = Rot3::new(Vec3::new(0.0f64, 0.0, 0.5 * <f64 as BaseFloat>::pi()));
 ///     let v  = Vec3::new(1.0, 0.0, 0.0);
 ///
 ///     let tv = na::inv_rotate(&t, &v);

--- a/src/structs/dmat.rs
+++ b/src/structs/dmat.rs
@@ -498,7 +498,7 @@ impl<N: Clone + Copy> Transpose for DMat<N> {
 impl<N: BaseNum + Cast<f64> + Clone> Mean<DVec<N>> for DMat<N> {
     fn mean(&self) -> DVec<N> {
         let mut res: DVec<N> = DVec::new_zeros(self.ncols);
-        let normalizer: N    = Cast::from(1.0f64 / Cast::from(self.nrows));
+        let normalizer: N    = Cast::from(1.0f64 / self.nrows as f64);
 
         for i in 0..self.nrows {
             for j in 0..self.ncols {


### PR DESCRIPTION
Resolves this error, which is fallout from
https://github.com/rust-lang/rust/pull/23673:

```
src/structs/dmat.rs:501:43: 501:74 error: type annotations required: cannot resolve `<f64 as core::ops::Div<_>>::Output == f64` [E0284]
src/structs/dmat.rs:501         let normalizer: N    = Cast::from(1.0f64 / Cast::from(self.nrows));
                                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Signed-off-by: Anders Kaseorg <andersk@mit.edu>