### PR TITLE
Remove Neg from BaseNum

### DIFF
--- a/src/structs/iso.rs
+++ b/src/structs/iso.rs
@@ -2,7 +2,7 @@
 
 #![allow(missing_docs)]
 
-use std::ops::{Add, Sub, Mul};
+use std::ops::{Add, Sub, Mul, Neg};
 
 use rand::{Rand, Rng};
 use structs::mat::{Mat3, Mat4, Mat5};

--- a/src/structs/iso_macros.rs
+++ b/src/structs/iso_macros.rs
@@ -278,7 +278,7 @@ macro_rules! transform_impl(
 
 macro_rules! inv_impl(
     ($t: ident) => (
-        impl<N: BaseNum> Inv for $t<N> {
+        impl<N: BaseNum + Neg<Output = N>> Inv for $t<N> {
             #[inline]
             fn inv_mut(&mut self) -> bool {
                 self.rotation.inv_mut();

--- a/src/structs/quat.rs
+++ b/src/structs/quat.rs
@@ -365,7 +365,7 @@ impl<N: BaseNum> Mul<Pnt3<N>> for UnitQuat<N> {
     }
 }
 
-impl<N: BaseNum> Mul<UnitQuat<N>> for Vec3<N> {
+impl<N: BaseNum + Neg<Output = N>> Mul<UnitQuat<N>> for Vec3<N> {
     type Output = Vec3<N>;
 
     #[inline]
@@ -378,7 +378,7 @@ impl<N: BaseNum> Mul<UnitQuat<N>> for Vec3<N> {
     }
 }
 
-impl<N: BaseNum> Mul<UnitQuat<N>> for Pnt3<N> {
+impl<N: BaseNum + Neg<Output = N>> Mul<UnitQuat<N>> for Pnt3<N> {
     type Output = Pnt3<N>;
 
     #[inline]
@@ -433,7 +433,7 @@ impl<N: BaseFloat> Rotation<Vec3<N>> for UnitQuat<N> {
     }
 }
 
-impl<N: BaseNum> Rotate<Vec3<N>> for UnitQuat<N> {
+impl<N: BaseNum + Neg<Output = N>> Rotate<Vec3<N>> for UnitQuat<N> {
     #[inline]
     fn rotate(&self, v: &Vec3<N>) -> Vec3<N> {
         *self * *v
@@ -445,7 +445,7 @@ impl<N: BaseNum> Rotate<Vec3<N>> for UnitQuat<N> {
     }
 }
 
-impl<N: BaseNum> Rotate<Pnt3<N>> for UnitQuat<N> {
+impl<N: BaseNum + Neg<Output = N>> Rotate<Pnt3<N>> for UnitQuat<N> {
     #[inline]
     fn rotate(&self, p: &Pnt3<N>) -> Pnt3<N> {
         *self * *p
@@ -457,7 +457,7 @@ impl<N: BaseNum> Rotate<Pnt3<N>> for UnitQuat<N> {
     }
 }
 
-impl<N: BaseNum> Transform<Vec3<N>> for UnitQuat<N> {
+impl<N: BaseNum + Neg<Output = N>> Transform<Vec3<N>> for UnitQuat<N> {
     #[inline]
     fn transform(&self, v: &Vec3<N>) -> Vec3<N> {
         *self * *v
@@ -469,7 +469,7 @@ impl<N: BaseNum> Transform<Vec3<N>> for UnitQuat<N> {
     }
 }
 
-impl<N: BaseNum> Transform<Pnt3<N>> for UnitQuat<N> {
+impl<N: BaseNum + Neg<Output = N>> Transform<Pnt3<N>> for UnitQuat<N> {
     #[inline]
     fn transform(&self, p: &Pnt3<N>) -> Pnt3<N> {
         *self * *p

--- a/src/structs/spec/mat.rs
+++ b/src/structs/spec/mat.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Mul};
+use std::ops::{Add, Mul, Neg};
 use structs::vec::{Vec2, Vec3};
 use structs::pnt::{Pnt2, Pnt3};
 use structs::mat::{Mat1, Mat2, Mat3};
@@ -32,7 +32,7 @@ impl<N: BaseNum + ApproxEq<N>> Inv for Mat1<N> {
     }
 }
 
-impl<N: BaseNum + ApproxEq<N>> Inv for Mat2<N> {
+impl<N: BaseNum + Neg<Output = N> + ApproxEq<N>> Inv for Mat2<N> {
     #[inline]
     fn inv(&self) -> Option<Mat2<N>> {
         let mut res = *self;
@@ -61,7 +61,7 @@ impl<N: BaseNum + ApproxEq<N>> Inv for Mat2<N> {
     }
 }
 
-impl<N: BaseNum + ApproxEq<N>> Inv for Mat3<N> {
+impl<N: BaseNum + Neg<Output = N> + ApproxEq<N>> Inv for Mat3<N> {
     #[inline]
     fn inv(&self) -> Option<Mat3<N>> {
         let mut res = *self;

--- a/src/traits/structure.rs
+++ b/src/traits/structure.rs
@@ -3,7 +3,7 @@
 use std::{f32, f64, i8, i16, i32, i64, u8, u16, u32, u64, isize, usize};
 use std::num::Float;
 use std::slice::{Iter, IterMut};
-use std::ops::{Add, Sub, Mul, Div, Neg, Rem, Index, IndexMut};
+use std::ops::{Add, Sub, Mul, Div, Rem, Index, IndexMut};
 use traits::operations::{RMul, LMul, Axpy, Transpose, Inv, Absolute};
 use traits::geometry::{Dot, Norm, Orig};
 
@@ -11,7 +11,7 @@ use traits::geometry::{Dot, Norm, Orig};
 pub trait BaseNum: Copy + Zero + One +
                    Add<Self, Output = Self> + Sub<Self, Output = Self> +
                    Mul<Self, Output = Self> + Div<Self, Output = Self> +
-                   Rem<Self, Output = Self> + Neg<Output = Self> + PartialEq +
+                   Rem<Self, Output = Self> + PartialEq +
                    Absolute<Self> + Axpy<Self> {
 }
 
@@ -239,7 +239,6 @@ pub trait VecAsPnt<P> {
 pub trait NumVec<N>: Dim +
                      Sub<Self, Output = Self> + Add<Self, Output = Self> +
                      Mul<N, Output = Self> + Div<N, Output = Self> + 
-                     Neg<Output = Self> +
                      Index<usize, Output = N> +
                      Zero + PartialEq + Dot<N> + Axpy<N> {
 }
@@ -276,7 +275,6 @@ pub trait NumPnt<N, V>:
           PartialEq +
           Axpy<N> +
           Sub<Self, Output = V> +
-          Neg<Output = Self>    +
           Mul<N, Output = Self> +
           Div<N, Output = Self> +
           Add<V, Output = Self> +


### PR DESCRIPTION
As per rust-lang/rust#23945, `Neg` is no longer implemented for unsigned types.