### PR TITLE
FRAC_2_SQRTPI was renamed to FRAC_2_SQRT_PI

### DIFF
--- a/src/traits/structure.rs
+++ b/src/traits/structure.rs
@@ -427,7 +427,7 @@ macro_rules! impl_base_float(
 
             /// 2.0 / sqrt(pi).
             fn frac_2_sqrtpi() -> $n {
-                $n::consts::FRAC_2_SQRTPI
+                $n::consts::FRAC_2_SQRT_PI
             }
 
 


### PR DESCRIPTION
The old name is deprecated.

Question: Do we want to rename `frac_2_sqrtpi()` to `frac_2_sqrt_pi()` as well for consistency, or keep the old name for compatibility, or add both names and deprecate the old one?