### PR TITLE
frac_2_sqrt_pi renaming

### DIFF
--- a/src/traits/structure.rs
+++ b/src/traits/structure.rs
@@ -36,7 +36,7 @@ pub trait BaseFloat: Float + Cast<f64> + BaseNum {
     /// 2.0 / pi.
     fn frac_2_pi() -> Self;
     /// 2.0 / sqrt(pi).
-    fn frac_2_sqrtpi() -> Self;
+    fn frac_2_sqrt_pi() -> Self;
 
     /// Euler's number.
     fn e() -> Self;
@@ -424,7 +424,7 @@ macro_rules! impl_base_float(
             }
 
             /// 2.0 / sqrt(pi).
-            fn frac_2_sqrtpi() -> $n {
+            fn frac_2_sqrt_pi() -> $n {
                 $n::consts::FRAC_2_SQRT_PI
             }
 

--- a/src/traits/structure.rs
+++ b/src/traits/structure.rs
@@ -425,7 +425,7 @@ macro_rules! impl_base_float(
 
             /// 2.0 / sqrt(pi).
             fn frac_2_sqrtpi() -> $n {
-                $n::consts::FRAC_2_SQRTPI
+                $n::consts::FRAC_2_SQRT_PI
             }
 
 


### PR DESCRIPTION
Expands on #115. Fixes #113.