### PR TITLE
Use the `Zero` and `One` traits from the `num` crate.

### DIFF
--- a/benches/common/macros.rs
+++ b/benches/common/macros.rs
@@ -8,8 +8,8 @@ macro_rules! bench_binop(
 
             let mut rng = IsaacRng::new_unseeded();
 
-            let elems1: Vec<$t1> = (0us .. LEN).map(|_| rng.gen::<$t1>()).collect();
-            let elems2: Vec<$t2> = (0us .. LEN).map(|_| rng.gen::<$t2>()).collect();
+            let elems1: Vec<$t1> = (0usize .. LEN).map(|_| rng.gen::<$t1>()).collect();
+            let elems2: Vec<$t2> = (0usize .. LEN).map(|_| rng.gen::<$t2>()).collect();
             let mut i = 0;
 
             bh.iter(|| {
@@ -31,8 +31,8 @@ macro_rules! bench_binop_na(
 
             let mut rng = IsaacRng::new_unseeded();
 
-            let elems1: Vec<$t1> = (0us .. LEN).map(|_| rng.gen::<$t1>()).collect();
-            let elems2: Vec<$t2> = (0us .. LEN).map(|_| rng.gen::<$t2>()).collect();
+            let elems1: Vec<$t1> = (0usize .. LEN).map(|_| rng.gen::<$t1>()).collect();
+            let elems2: Vec<$t2> = (0usize .. LEN).map(|_| rng.gen::<$t2>()).collect();
             let mut i = 0;
 
             bh.iter(|| {
@@ -54,7 +54,7 @@ macro_rules! bench_unop(
 
             let mut rng = IsaacRng::new_unseeded();
 
-            let elems: Vec<$t> =  (0us .. LEN).map(|_| rng.gen::<$t>()).collect();
+            let elems: Vec<$t> =  (0usize .. LEN).map(|_| rng.gen::<$t>()).collect();
             let mut i = 0;
 
             bh.iter(|| {
@@ -76,7 +76,7 @@ macro_rules! bench_unop_self(
 
             let mut rng = IsaacRng::new_unseeded();
 
-            let mut elems: Vec<$t> =  (0us .. LEN).map(|_| rng.gen::<$t>()).collect();
+            let mut elems: Vec<$t> =  (0usize .. LEN).map(|_| rng.gen::<$t>()).collect();
             let mut i = 0;
 
             bh.iter(|| {
@@ -98,7 +98,7 @@ macro_rules! bench_construction(
 
             let mut rng = IsaacRng::new_unseeded();
 
-            $(let $args: Vec<$types> = (0us .. LEN).map(|_| rng.gen::<$types>()).collect();)*
+            $(let $args: Vec<$types> = (0usize .. LEN).map(|_| rng.gen::<$types>()).collect();)*
             let mut i = 0;
 
             bh.iter(|| {

--- a/benches/dmat.rs
+++ b/benches/dmat.rs
@@ -13,7 +13,7 @@ macro_rules! bench_mul_dmat(
                 let a:     DMat<f64> = DMat::new_random($nrows, $ncols);
                 let mut b: DMat<f64> = DMat::new_random($nrows, $ncols);
 
-                for _ in (0us .. 1000) {
+                for _ in (0usize .. 1000) {
                     // XXX: the clone here is highly undesirable!
                     b = a.clone() * b;
                 }
@@ -55,7 +55,7 @@ macro_rules! bench_mul_dmat_dvec(
                 let m : DMat<f64>     = DMat::new_random($nrows, $ncols);
                 let mut v : DVec<f64> = DVec::new_random($ncols);
 
-                for _ in (0us .. 1000) {
+                for _ in (0usize .. 1000) {
                     // XXX: the clone here is highly undesirable!
                     v = m.clone() * v
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,6 @@ Feel free to add your project to this list if you happen to use **nalgebra**!
 #![deny(unused_qualifications)]
 #![deny(unused_results)]
 #![warn(missing_docs)]
-#![cfg_attr(test, feature(test))]
 #![doc(html_root_url = "http://nalgebra.org/doc")]
 
 extern crate rustc_serialize;
@@ -92,11 +91,9 @@ extern crate num;
 #[cfg(feature="arbitrary")]
 extern crate quickcheck;
 
-#[cfg(test)]
-extern crate test;
-
 use std::cmp;
 use std::ops::{Neg, Mul};
+use num::{Zero, One};
 pub use traits::{
     Absolute,
     AbsoluteRotate,
@@ -131,7 +128,6 @@ pub use traits::{
     Norm,
     NumPnt,
     NumVec,
-    One,
     Orig,
     Outer,
     POrd,
@@ -150,7 +146,6 @@ pub use traits::{
     Transpose,
     UniformSphereSample,
     VecAsPnt,
-    Zero
 };
 
 pub use structs::{

--- a/src/structs/dmat.rs
+++ b/src/structs/dmat.rs
@@ -7,9 +7,10 @@ use std::iter::repeat;
 use std::ops::{Add, Sub, Mul, Div, Index, IndexMut};
 use std::fmt::{Debug, Display, Formatter, Result};
 use rand::{self, Rand};
+use num::{Zero, One};
 use structs::dvec::DVec;
 use traits::operations::{ApproxEq, Inv, Transpose, Mean, Cov};
-use traits::structure::{Cast, ColSlice, RowSlice, Diag, Eye, Indexable, Shape, Zero, One, BaseNum};
+use traits::structure::{Cast, ColSlice, RowSlice, Diag, Eye, Indexable, Shape, BaseNum};
 #[cfg(feature="arbitrary")]
 use quickcheck::{Arbitrary, Gen};
 

--- a/src/structs/dvec.rs
+++ b/src/structs/dvec.rs
@@ -7,9 +7,10 @@ use std::iter::{FromIterator, IntoIterator};
 use std::iter::repeat;
 use std::ops::{Add, Sub, Mul, Div, Neg, Index, IndexMut};
 use rand::{self, Rand};
+use num::{Zero, One};
 use traits::operations::{ApproxEq, Axpy};
 use traits::geometry::{Dot, Norm};
-use traits::structure::{Iterable, IterableMut, Indexable, Shape, BaseFloat, BaseNum, Zero, One};
+use traits::structure::{Iterable, IterableMut, Indexable, Shape, BaseFloat, BaseNum};
 #[cfg(feature="arbitrary")]
 use quickcheck::{Arbitrary, Gen};
 

--- a/src/structs/iso.rs
+++ b/src/structs/iso.rs
@@ -5,8 +5,9 @@
 use std::ops::{Add, Sub, Mul, Neg};
 
 use rand::{Rand, Rng};
+use num::One;
 use structs::mat::{Mat3, Mat4, Mat5};
-use traits::structure::{Cast, Dim, Col, BaseFloat, BaseNum, One};
+use traits::structure::{Cast, Dim, Col, BaseFloat, BaseNum};
 use traits::operations::{Inv, ApproxEq};
 use traits::geometry::{RotationMatrix, Rotation, Rotate, AbsoluteRotate, Transform, Transformation,
                        Translate, Translation, ToHomogeneous};

--- a/src/structs/mat.rs
+++ b/src/structs/mat.rs
@@ -6,13 +6,14 @@ use std::ops::{Add, Sub, Mul, Div, Index, IndexMut};
 use std::mem;
 use std::slice::{Iter, IterMut};
 use rand::{Rand, Rng};
+use num::{Zero, One};
 use traits::operations::ApproxEq;
 use structs::vec::{Vec1, Vec2, Vec3, Vec4, Vec5, Vec6};
 use structs::pnt::{Pnt1, Pnt4, Pnt5, Pnt6};
 use structs::dvec::{DVec1, DVec2, DVec3, DVec4, DVec5, DVec6};
 
 use traits::structure::{Cast, Row, Col, Iterable, IterableMut, Dim, Indexable,
-                        Eye, ColSlice, RowSlice, Diag, Shape, BaseFloat, BaseNum, Zero, One};
+                        Eye, ColSlice, RowSlice, Diag, Shape, BaseFloat, BaseNum};
 use traits::operations::{Absolute, Transpose, Inv, Outer, EigenQR};
 use traits::geometry::{ToHomogeneous, FromHomogeneous, Orig};
 use linalg;

--- a/src/structs/pnt.rs
+++ b/src/structs/pnt.rs
@@ -8,10 +8,11 @@ use std::slice::{Iter, IterMut};
 use std::iter::{Iterator, FromIterator, IntoIterator};
 use std::ops::{Add, Sub, Mul, Div, Neg, Index, IndexMut};
 use rand::{Rand, Rng};
+use num::{Zero, One};
 use traits::operations::{ApproxEq, POrd, POrdering, Axpy, ScalarAdd, ScalarSub, ScalarMul,
                          ScalarDiv};
 use traits::structure::{Cast, Dim, Indexable, Iterable, IterableMut, PntAsVec, Shape,
-                        NumPnt, FloatPnt, BaseFloat, BaseNum, Zero, One, Bounded};
+                        NumPnt, FloatPnt, BaseFloat, BaseNum, Bounded};
 use traits::geometry::{Orig, FromHomogeneous, ToHomogeneous};
 use structs::vec::{Vec1, Vec2, Vec3, Vec4, Vec5, Vec6};
 #[cfg(feature="arbitrary")]

--- a/src/structs/quat.rs
+++ b/src/structs/quat.rs
@@ -7,11 +7,12 @@ use std::slice::{Iter, IterMut};
 use std::ops::{Add, Sub, Mul, Div, Neg, Index, IndexMut};
 use std::iter::{FromIterator, IntoIterator};
 use rand::{Rand, Rng};
+use num::{Zero, One};
 use structs::{Vec3, Pnt3, Rot3, Mat3};
 use traits::operations::{ApproxEq, Inv, POrd, POrdering, Axpy, ScalarAdd, ScalarSub, ScalarMul,
                          ScalarDiv};
-use traits::structure::{Cast, Indexable, Iterable, IterableMut, Dim, Shape, BaseFloat, BaseNum, Zero,
-                        One, Bounded};
+use traits::structure::{Cast, Indexable, Iterable, IterableMut, Dim, Shape, BaseFloat, BaseNum,
+                        Bounded};
 use traits::geometry::{Norm, Rotation, Rotate, Transform};
 
 #[cfg(feature="arbitrary")]

--- a/src/structs/rot.rs
+++ b/src/structs/rot.rs
@@ -4,9 +4,10 @@
 
 use std::ops::{Mul, Neg, Index};
 use rand::{Rand, Rng};
+use num::{Zero, One};
 use traits::geometry::{Rotate, Rotation, AbsoluteRotate, RotationMatrix, Transform, ToHomogeneous,
                        Norm, Cross};
-use traits::structure::{Cast, Dim, Row, Col, BaseFloat, BaseNum, Zero, One};
+use traits::structure::{Cast, Dim, Row, Col, BaseFloat, BaseNum, };
 use traits::operations::{Absolute, Inv, Transpose, ApproxEq};
 use structs::vec::{Vec1, Vec2, Vec3, Vec4};
 use structs::pnt::{Pnt2, Pnt3, Pnt4};

--- a/src/structs/spec/identity.rs
+++ b/src/structs/spec/identity.rs
@@ -1,7 +1,7 @@
 use std::ops::Mul;
+use num::{Zero, One};
 use structs::mat;
 use traits::operations::{Inv, Transpose};
-use traits::structure::{Zero, One};
 use traits::geometry::{Translation, Translate, Rotation, Rotate, Transformation, Transform,
                        AbsoluteRotate};
 

--- a/src/structs/spec/vec.rs
+++ b/src/structs/spec/vec.rs
@@ -1,5 +1,6 @@
 use std::ops::{Sub, Mul, Neg};
-use traits::structure::{Cast, Row, Basis, BaseFloat, Zero, One};
+use num::{Zero, One};
+use traits::structure::{Cast, Row, Basis, BaseFloat};
 use traits::geometry::{Norm, Cross, CrossMatrix, UniformSphereSample};
 use structs::vec::{Vec1, Vec2, Vec3, Vec4};
 use structs::mat::Mat3;
@@ -228,7 +229,8 @@ static SAMPLES_3_F64: [Vec3<f64>; 42] = [
     Vec3 { x: 0.162456 , y: 0.499995 , z: 0.850654 }
 ];
 
-impl<N: One + Copy> UniformSphereSample for Vec1<N> {
+impl<N> UniformSphereSample for Vec1<N>
+    where Vec1<N>: One {
     #[inline(always)]
     fn sample<F: FnMut(Vec1<N>)>(mut f: F) {
         f(::one())

--- a/src/structs/spec/vec0.rs
+++ b/src/structs/spec/vec0.rs
@@ -4,9 +4,9 @@ use std::mem;
 use std::slice::{Iter, IterMut};
 use std::iter::{FromIterator, IntoIterator};
 use rand::{Rand, Rng};
+use num::{Zero, One};
 use traits::operations::ApproxEq;
-use traits::structure::{Iterable, IterableMut, Indexable, Basis, Dim, Shape, BaseFloat, BaseNum,
-                        Zero, One, Bounded};
+use traits::structure::{Iterable, IterableMut, Indexable, Basis, Dim, Shape, BaseFloat, BaseNum, Bounded};
 use traits::geometry::{Translation, Dot, Norm};
 use structs::vec;
 

--- a/src/structs/vec.rs
+++ b/src/structs/vec.rs
@@ -8,12 +8,13 @@ use std::mem;
 use std::slice::{Iter, IterMut};
 use std::iter::{Iterator, FromIterator, IntoIterator};
 use rand::{Rand, Rng};
+use num::{Zero, One};
 use traits::operations::{ApproxEq, POrd, POrdering, Axpy, ScalarAdd, ScalarSub, ScalarMul,
                          ScalarDiv, Absolute};
 use traits::geometry::{Transform, Rotate, FromHomogeneous, ToHomogeneous, Dot, Norm,
                        Translation, Translate};
 use traits::structure::{Basis, Cast, Dim, Indexable, Iterable, IterableMut, VecAsPnt, Shape,
-                        NumVec, FloatVec, BaseFloat, BaseNum, Zero, One, Bounded};
+                        NumVec, FloatVec, BaseFloat, BaseNum, Bounded};
 use structs::pnt::{Pnt1, Pnt2, Pnt3, Pnt4, Pnt5, Pnt6};
 
 #[cfg(feature="arbitrary")]

--- a/src/structs/vec_macros.rs
+++ b/src/structs/vec_macros.rs
@@ -651,7 +651,8 @@ macro_rules! approx_eq_impl(
 
 macro_rules! zero_one_impl(
     ($t: ident, $($compN: ident),+) => (
-        impl<N: One> One for $t<N> {
+        impl<N> One for $t<N>
+            where N: Copy + One + Sub<N, Output = N> + Add<N, Output = N> {
             #[inline]
             fn one() -> $t<N> {
                 $t {

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -6,8 +6,7 @@ pub use traits::geometry::{AbsoluteRotate, Cross, CrossMatrix, Dot, FromHomogene
 
 pub use traits::structure::{FloatVec, FloatPnt, Basis, Cast, Col, Dim, Indexable, Iterable,
                             IterableMut, Mat, SquareMat, Row, NumVec, NumPnt, PntAsVec, VecAsPnt,
-                            ColSlice, RowSlice, Diag, Eye, Shape, BaseFloat, BaseNum, Zero, One,
-                            Bounded};
+                            ColSlice, RowSlice, Diag, Eye, Shape, BaseFloat, BaseNum, Bounded};
 
 pub use traits::operations::{Absolute, ApproxEq, Axpy, Cov, Det, Inv, LMul, Mean, Outer, POrd,
                              RMul, ScalarAdd, ScalarSub, ScalarMul, ScalarDiv, Transpose, EigenQR};

--- a/src/traits/structure.rs
+++ b/src/traits/structure.rs
@@ -3,7 +3,7 @@
 use std::{f32, f64, i8, i16, i32, i64, u8, u16, u32, u64, isize, usize};
 use std::slice::{Iter, IterMut};
 use std::ops::{Add, Sub, Mul, Div, Rem, Index, IndexMut};
-use num::Float;
+use num::{Float, Zero, One};
 use traits::operations::{RMul, LMul, Axpy, Transpose, Inv, Absolute};
 use traits::geometry::{Dot, Norm, Orig};
 
@@ -78,20 +78,6 @@ impl<N, V, M> SquareMat<N, V> for M
 pub trait Eye {
     /// Return the identity matrix of specified dimension
     fn new_identity(dim: usize) -> Self;
-}
-
-/// Additive identity.
-pub trait Zero {
-    /// Returns the additive identity.
-    fn zero() -> Self;
-    /// Tests if `self` is exactly zero.
-    fn is_zero(&self) -> bool;
-}
-
-/// Multiplicative identity.
-pub trait One {
-    /// Returns the multiplicative identity.
-    fn one() -> Self;
 }
 
 /// Types that have maximum and minimum value.
@@ -303,46 +289,6 @@ pub trait FloatPnt<N: BaseFloat, V: Norm<N>>: NumPnt<N, V> + Sized {
  *
  *
  */
-
-
-
-// Zero and One
-macro_rules! impl_zero_one(
-    ($n: ty, $zero: expr, $one: expr) => {
-        impl Zero for $n {
-            #[inline]
-            fn zero() -> $n {
-                $zero
-            }
-
-            #[inline]
-            fn is_zero(&self) -> bool {
-                *self == $zero
-            }
-        }
-
-        impl One for $n {
-            fn one() -> $n {
-                $one
-            }
-        }
-    }
-);
-
-impl_zero_one!(f32, 0.0, 1.0);
-impl_zero_one!(f64, 0.0, 1.0);
-impl_zero_one!(i8, 0, 1);
-impl_zero_one!(i16, 0, 1);
-impl_zero_one!(i32, 0, 1);
-impl_zero_one!(i64, 0, 1);
-impl_zero_one!(isize, 0, 1);
-impl_zero_one!(u8, 0, 1);
-impl_zero_one!(u16, 0, 1);
-impl_zero_one!(u32, 0, 1);
-impl_zero_one!(u64, 0, 1);
-impl_zero_one!(usize, 0, 1);
-
-
 // Bounded
 macro_rules! impl_bounded(
     ($n: ty, $min: expr, $max: expr) => {


### PR DESCRIPTION
Remove our own definitions of those traits.
Also fixes test-related attributes to make them compile again.