### PR TITLE
This reference should not be mut

### DIFF
--- a/src/structs/mat_macros.rs
+++ b/src/structs/mat_macros.rs
@@ -292,7 +292,7 @@ macro_rules! index_impl(
 
             fn index(&self, (i, j): (usize, usize)) -> &N {
                 unsafe {
-                    &mem::transmute::<&$t<N>, &mut [N; $dim * $dim]>(self)[i + j * $dim]
+                    &mem::transmute::<&$t<N>, & [N; $dim * $dim]>(self)[i + j * $dim]
                 }
             }
         }


### PR DESCRIPTION
Found this little bug, it's picked up by a new linter in the nightly