### PR TITLE
Add 'rustc-serialize' and 'serde-serialize' features.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,23 @@ name = "nalgebra"
 path = "src/lib.rs"
 
 [features]
+default = ["rustc-serialize"]
+serde-serialize = ["serde", "serde_macros"]
 # Generate arbitrary instances of nalgebra types for testing with quickcheck
 arbitrary = ["quickcheck"]
 
 [dependencies]
-rustc-serialize = "*"
 rand = "*"
 num = "*"
+
+[dependencies.rustc-serialize]
+optional = true
+
+[dependencies.serde]
+optional = true
+
+[dependencies.serde_macros]
+optional = true
 
 [dependencies.quickcheck]
 optional = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,9 +73,17 @@ Feel free to add your project to this list if you happen to use **nalgebra**!
 #![warn(missing_docs)]
 #![doc(html_root_url = "http://nalgebra.org/doc")]
 
-extern crate rustc_serialize;
+#![cfg_attr(feature = "serde-serialize", feature(custom_derive, plugin))]
+#![cfg_attr(feature = "serde-serialize", plugin(serde_macros))]
+
 extern crate rand;
 extern crate num;
+
+#[cfg(feature = "rustc-serialize")]
+extern crate rustc_serialize;
+
+#[cfg(feature = "serde-serialize")]
+extern crate serde;
 
 #[cfg(feature="arbitrary")]
 extern crate quickcheck;

--- a/src/structs/iso.rs
+++ b/src/structs/iso.rs
@@ -25,7 +25,9 @@ use quickcheck::{Arbitrary, Gen};
 /// This is the composition of a rotation followed by a translation.
 /// Isometries conserve angles and distances, hence do not allow shearing nor scaling.
 #[repr(C)]
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Debug, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Debug, Copy)]
 pub struct Iso2<N> {
     /// The rotation applicable by this isometry.
     pub rotation:    Rot2<N>,
@@ -38,7 +40,9 @@ pub struct Iso2<N> {
 /// This is the composition of a rotation followed by a translation.
 /// Isometries conserve angles and distances, hence do not allow shearing nor scaling.
 #[repr(C)]
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Debug, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Debug, Copy)]
 pub struct Iso3<N> {
     /// The rotation applicable by this isometry.
     pub rotation:    Rot3<N>,
@@ -50,7 +54,9 @@ pub struct Iso3<N> {
 ///
 /// Isometries conserve angles and distances, hence do not allow shearing nor scaling.
 #[repr(C)]
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Debug, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Debug, Copy)]
 pub struct Iso4<N> {
     /// The rotation applicable by this isometry.
     pub rotation:    Rot4<N>,

--- a/src/structs/mat.rs
+++ b/src/structs/mat.rs
@@ -23,7 +23,9 @@ use quickcheck::{Arbitrary, Gen};
 
 /// Special identity matrix. All its operation are no-ops.
 #[repr(C)]
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Debug, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Debug, Copy)]
 pub struct Identity;
 
 impl Identity {
@@ -36,7 +38,9 @@ impl Identity {
 
 /// Square matrix of dimension 1.
 #[repr(C)]
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Hash, Debug, Copy)]
 pub struct Mat1<N> {
     pub m11: N
 }
@@ -84,7 +88,9 @@ rand_impl!(Mat1, m11);
 
 /// Square matrix of dimension 2.
 #[repr(C)]
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Hash, Debug, Copy)]
 pub struct Mat2<N> {
     pub m11: N, pub m21: N,
     pub m12: N, pub m22: N
@@ -137,7 +143,9 @@ rand_impl!(Mat2, m11, m12, m21, m22);
 
 /// Square matrix of dimension 3.
 #[repr(C)]
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Hash, Debug, Copy)]
 pub struct Mat3<N> {
     pub m11: N, pub m21: N, pub m31: N,
     pub m12: N, pub m22: N, pub m32: N,
@@ -233,7 +241,9 @@ rand_impl!(Mat3,
 
 /// Square matrix of dimension 4.
 #[repr(C)]
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Hash, Debug, Copy)]
 pub struct Mat4<N> {
     pub m11: N, pub m21: N, pub m31: N, pub m41: N,
     pub m12: N, pub m22: N, pub m32: N, pub m42: N,
@@ -352,7 +362,9 @@ rand_impl!(Mat4,
 
 /// Square matrix of dimension 5.
 #[repr(C)]
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Hash, Debug, Copy)]
 pub struct Mat5<N> {
     pub m11: N, pub m21: N, pub m31: N, pub m41: N, pub m51: N,
     pub m12: N, pub m22: N, pub m32: N, pub m42: N, pub m52: N,
@@ -488,7 +500,9 @@ rand_impl!(Mat5,
 
 /// Square matrix of dimension 6.
 #[repr(C)]
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Hash, Debug, Copy)]
 pub struct Mat6<N> {
     pub m11: N, pub m21: N, pub m31: N, pub m41: N, pub m51: N, pub m61: N,
     pub m12: N, pub m22: N, pub m32: N, pub m42: N, pub m52: N, pub m62: N,

--- a/src/structs/ortho.rs
+++ b/src/structs/ortho.rs
@@ -8,7 +8,9 @@ use quickcheck::{Arbitrary, Gen};
 /// A 3D orthographic projection stored without any matrix.
 ///
 /// Reading or modifying its individual properties is cheap but applying the transformation is costly.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Debug, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Debug, Copy)]
 pub struct Ortho3<N> {
     width:  N,
     height: N,
@@ -19,7 +21,9 @@ pub struct Ortho3<N> {
 /// A 3D orthographic projection stored as a 4D matrix.
 ///
 /// Reading or modifying its individual properties is costly but applying the transformation is cheap.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Debug, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Debug, Copy)]
 pub struct OrthoMat3<N> {
     mat: Mat4<N>
 }

--- a/src/structs/persp.rs
+++ b/src/structs/persp.rs
@@ -8,7 +8,9 @@ use quickcheck::{Arbitrary, Gen};
 /// A 3D perspective projection stored without any matrix.
 ///
 /// Reading or modifying its individual properties is cheap but applying the transformation is costly.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Debug, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Debug, Copy)]
 pub struct Persp3<N> {
     aspect: N,
     fov:    N,
@@ -19,7 +21,9 @@ pub struct Persp3<N> {
 /// A 3D perspective projection stored as a 4D matrix.
 ///
 /// Reading or modifying its individual properties is costly but applying the transformation is cheap.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Debug, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Debug, Copy)]
 pub struct PerspMat3<N> {
     mat: Mat4<N>
 }

--- a/src/structs/pnt.rs
+++ b/src/structs/pnt.rs
@@ -40,7 +40,9 @@ impl<N> Repeat<N> for Pnt0<N> {
 
 /// Point of dimension 1.
 #[repr(C)]
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Hash, Debug, Copy)]
 pub struct Pnt1<N> {
     /// First component of the point.
     pub x: N
@@ -80,7 +82,9 @@ rand_impl!(Pnt1, x);
 
 /// Point of dimension 2.
 #[repr(C)]
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Hash, Debug, Copy)]
 pub struct Pnt2<N> {
     /// First component of the point.
     pub x: N,
@@ -122,7 +126,9 @@ rand_impl!(Pnt2, x, y);
 
 /// Point of dimension 3.
 #[repr(C)]
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Hash, Debug, Copy)]
 pub struct Pnt3<N> {
     /// First component of the point.
     pub x: N,
@@ -166,7 +172,9 @@ rand_impl!(Pnt3, x, y, z);
 
 /// Point of dimension 4.
 #[repr(C)]
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Hash, Debug, Copy)]
 pub struct Pnt4<N> {
     /// First component of the point.
     pub x: N,
@@ -212,7 +220,9 @@ rand_impl!(Pnt4, x, y, z, w);
 
 /// Point of dimension 5.
 #[repr(C)]
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Hash, Debug, Copy)]
 pub struct Pnt5<N> {
     /// First component of the point.
     pub x: N,
@@ -260,7 +270,9 @@ rand_impl!(Pnt5, x, y, z, w, a);
 
 /// Point of dimension 6.
 #[repr(C)]
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Hash, Debug, Copy)]
 pub struct Pnt6<N> {
     /// First component of the point.
     pub x: N,

--- a/src/structs/quat.rs
+++ b/src/structs/quat.rs
@@ -20,7 +20,9 @@ use quickcheck::{Arbitrary, Gen};
 
 /// A quaternion.
 #[repr(C)]
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Hash, Debug, Copy)]
 pub struct Quat<N> {
     /// The scalar component of the quaternion.
     pub w: N,
@@ -159,7 +161,9 @@ impl<N: ApproxEq<N> + BaseFloat> Div<Quat<N>> for Quat<N> {
 
 /// A unit quaternion that can represent a 3D rotation.
 #[repr(C)]
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Hash, Debug, Copy)]
 pub struct UnitQuat<N> {
     q: Quat<N>
 }

--- a/src/structs/rot.rs
+++ b/src/structs/rot.rs
@@ -18,7 +18,9 @@ use quickcheck::{Arbitrary, Gen};
 
 /// Two dimensional rotation matrix.
 #[repr(C)]
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Debug, Hash, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Debug, Hash, Copy)]
 pub struct Rot2<N> {
     submat: Mat2<N>
 }
@@ -119,7 +121,9 @@ impl<N: Arbitrary + Clone + BaseFloat + Neg<Output = N>> Arbitrary for Rot2<N> {
  */
 /// Three dimensional rotation matrix.
 #[repr(C)]
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Debug, Hash, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Debug, Hash, Copy)]
 pub struct Rot3<N> {
     submat: Mat3<N>
 }
@@ -341,7 +345,9 @@ impl<N: Arbitrary + Clone + BaseFloat> Arbitrary for Rot3<N> {
 
 /// Four dimensional rotation matrix.
 #[repr(C)]
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Debug, Hash, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Debug, Hash, Copy)]
 pub struct Rot4<N> {
     submat: Mat4<N>
 }

--- a/src/structs/vec.rs
+++ b/src/structs/vec.rs
@@ -42,7 +42,9 @@ impl<N> Repeat<N> for Vec0<N> {
 
 /// Vector of dimension 1.
 #[repr(C)]
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Hash, Debug, Copy)]
 pub struct Vec1<N> {
     /// First component of the vector.
     pub x: N
@@ -93,7 +95,9 @@ rand_impl!(Vec1, x);
 
 /// Vector of dimension 2.
 #[repr(C)]
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Hash, Debug, Copy)]
 pub struct Vec2<N> {
     /// First component of the vector.
     pub x: N,
@@ -146,7 +150,9 @@ rand_impl!(Vec2, x, y);
 
 /// Vector of dimension 3.
 #[repr(C)]
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Hash, Debug, Copy)]
 pub struct Vec3<N> {
     /// First component of the vector.
     pub x: N,
@@ -202,7 +208,9 @@ rand_impl!(Vec3, x, y, z);
 
 /// Vector of dimension 4.
 #[repr(C)]
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Hash, Debug, Copy)]
 pub struct Vec4<N> {
     /// First component of the vector.
     pub x: N,
@@ -259,7 +267,9 @@ rand_impl!(Vec4, x, y, z, w);
 
 /// Vector of dimension 5.
 #[repr(C)]
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Hash, Debug, Copy)]
 pub struct Vec5<N> {
     /// First component of the vector.
     pub x: N,
@@ -318,7 +328,9 @@ rand_impl!(Vec5, x, y, z, w, a);
 
 /// Vector of dimension 6.
 #[repr(C)]
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Hash, Debug, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Hash, Debug, Copy)]
 pub struct Vec6<N> {
     /// First component of the vector.
     pub x: N,

--- a/src/traits/operations.rs
+++ b/src/traits/operations.rs
@@ -5,7 +5,9 @@ use std::cmp::Ordering;
 use traits::structure::SquareMat;
 
 /// Result of a partial ordering.
-#[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Debug, Copy)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Debug, Copy)]
 pub enum POrdering {
     /// Result of a strict comparison.
     PartialLess,


### PR DESCRIPTION
This allows users to choose rustc-serialize or serde (or both or none) for serializiation. 
'rustc-serialize' is a default feature, serde is activated through the 'serde-serialize' feature. 
If there's any interest in it, I'll eventually do the same for ncollide and nphysics.
