### PR TITLE
Don't run benchmarks on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,3 @@ script:
     - cargo --version
     - cargo build --verbose
     - cargo test --verbose --features arbitrary
-    - cargo bench --verbose


### PR DESCRIPTION
Benchmarks require `#[feature(test)]` which is not supported by the stable branch.