### PR TITLE
Allow for non-consuming std operations on DMat. Added DMat multiplication test.

### DIFF
--- a/src/structs/dmat.rs
+++ b/src/structs/dmat.rs
@@ -265,7 +265,35 @@ impl<N> IndexMut<(usize, usize)> for DMat<N> {
 impl<N: Copy + Mul<N, Output = N> + Add<N, Output = N> + Zero> Mul<DMat<N>> for DMat<N> {
     type Output = DMat<N>;
 
+    #[inline]
     fn mul(self, right: DMat<N>) -> DMat<N> {
+        (&self) * (&right)
+    }
+}
+
+impl<'a, N: Copy + Mul<N, Output = N> + Add<N, Output = N> + Zero> Mul<&'a DMat<N>> for DMat<N> {
+    type Output = DMat<N>;
+
+    #[inline]
+    fn mul(self, right: &'a DMat<N>) -> DMat<N> {
+        (&self) * right
+    }
+}
+
+impl<'a, N: Copy + Mul<N, Output = N> + Add<N, Output = N> + Zero> Mul<DMat<N>> for &'a DMat<N> {
+    type Output = DMat<N>;
+
+    #[inline]
+    fn mul(self, right: DMat<N>) -> DMat<N> {
+        right * self
+    }
+}
+
+impl<'a, N: Copy + Mul<N, Output = N> + Add<N, Output = N> + Zero> Mul<&'a DMat<N>> for &'a DMat<N> {
+    type Output = DMat<N>;
+
+    #[inline]
+    fn mul(self, right: &DMat<N>) -> DMat<N> {
         assert!(self.ncols == right.nrows);
 
         let mut res = unsafe { DMat::new_uninitialized(self.nrows, right.ncols) };
@@ -668,6 +696,15 @@ impl<N: Copy + Add<N, Output = N>> Add<DMat<N>> for DMat<N> {
 
     #[inline]
     fn add(self, right: DMat<N>) -> DMat<N> {
+        self + (&right)
+    }
+}
+
+impl<'a, N: Copy + Add<N, Output = N>> Add<&'a DMat<N>> for DMat<N> {
+    type Output = DMat<N>;
+
+    #[inline]
+    fn add(self, right: &'a DMat<N>) -> DMat<N> {
         assert!(self.nrows == right.nrows && self.ncols == right.ncols,
                 "Unable to add matrices with different dimensions.");
 
@@ -701,6 +738,15 @@ impl<N: Copy + Sub<N, Output = N>> Sub<DMat<N>> for DMat<N> {
 
     #[inline]
     fn sub(self, right: DMat<N>) -> DMat<N> {
+        self - (&right)
+    }
+}
+
+impl<'a, N: Copy + Sub<N, Output = N>> Sub<&'a DMat<N>> for DMat<N> {
+    type Output = DMat<N>;
+
+    #[inline]
+    fn sub(self, right: &'a DMat<N>) -> DMat<N> {
         assert!(self.nrows == right.nrows && self.ncols == right.ncols,
                 "Unable to subtract matrices with different dimensions.");
 

--- a/src/structs/dmat.rs
+++ b/src/structs/dmat.rs
@@ -700,6 +700,15 @@ impl<N: Copy + Add<N, Output = N>> Add<DMat<N>> for DMat<N> {
     }
 }
 
+impl<'a, N: Copy + Add<N, Output = N>> Add<DMat<N>> for &'a DMat<N> {
+    type Output = DMat<N>;
+
+    #[inline]
+    fn add(self, right: DMat<N>) -> DMat<N> {
+        right + self
+    }
+}
+
 impl<'a, N: Copy + Add<N, Output = N>> Add<&'a DMat<N>> for DMat<N> {
     type Output = DMat<N>;
 
@@ -739,6 +748,15 @@ impl<N: Copy + Sub<N, Output = N>> Sub<DMat<N>> for DMat<N> {
     #[inline]
     fn sub(self, right: DMat<N>) -> DMat<N> {
         self - (&right)
+    }
+}
+
+impl<'a, N: Copy + Sub<N, Output = N>> Sub<DMat<N>> for &'a DMat<N> {
+    type Output = DMat<N>;
+
+    #[inline]
+    fn sub(self, right: DMat<N>) -> DMat<N> {
+        right - self
     }
 }
 

--- a/tests/mat.rs
+++ b/tests/mat.rs
@@ -323,6 +323,38 @@ fn test_dmat_addition() {
 }
 
 #[test]
+fn test_dmat_multiplication() {
+   let mat1 = DMat::from_row_vec(
+        2,
+        2,
+        &[
+            1.0, 2.0,
+            3.0, 4.0
+        ]
+    );
+
+    let mat2 = DMat::from_row_vec(
+        2,
+        2,
+        &[
+            10.0, 20.0,
+            30.0, 40.0
+        ]
+    );
+
+    let res = DMat::from_row_vec(
+        2,
+        2,
+        &[
+            70.0, 100.0,
+            150.0, 220.0
+        ]
+    );
+
+    assert!((mat1 * mat2) == res);
+}
+
+#[test]
 fn test_dmat_subtraction() {
     let mat1 = DMat::from_row_vec(
         2,


### PR DESCRIPTION
Currently, the std operations (`Mul`, `Add` and `Sub`) consume both the lhs and rhs `DMat`s even though it is not always necessary or desired. This means a user must clone the `DMat` on the occasion that they only have access to the `DMat` by reference. As an example, the following isn't allowed:
```Rust
let NeuralNetwork { ref input_mat, ref weight_mat, .. } = *net;
let activity = *input_mat * *weight_mat; // error: cannot move out of borrowed content
```

This PR implements the std operations for `&'a DMat`, allowing the above example to work like so:
```Rust
let NeuralNetwork { ref input_mat, ref weight_mat, .. } = *net;
let activity = input_mat * weight_mat;
```

Specifically, the following are now possible:

```Rust
(&mat_a) * mat_b;
mat_a * (&mat_b);
(&mat_a) * (&mat_b);
mat_a + (&mat_b);
(&mat_a) + mat_b;
mat_a - (&mat_b);
(&mat_a) - mat_b;
```


I hope this is ok! Let me know your thoughts or if you'd prefer me to change anything :+1:

Edit: fixed example.