### PR TITLE
Remove implementations of `Rotation`, `Translation` and `Transformation` for the `Identity` type.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "nalgebra"
-version = "0.2.18"
+version = "0.2.19"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ] # FIXME: add the contributors.
 
 description = "Linear algebra library for computer physics, computer graphics and general low-dimensional linear algebra for Rust."

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ bench:
 	cargo bench
 
 doc:
-	cargo doc
+	cargo doc --no-deps
 
 clean:
 	cargo clean

--- a/src/structs/spec/identity.rs
+++ b/src/structs/spec/identity.rs
@@ -1,9 +1,8 @@
 use std::ops::Mul;
-use num::{Zero, One};
+use num::One;
 use structs::mat;
 use traits::operations::{Inv, Transpose};
-use traits::geometry::{Translation, Translate, Rotation, Rotate, Transformation, Transform,
-                       AbsoluteRotate};
+use traits::geometry::{Translate, Rotate, Transform, AbsoluteRotate};
 
 impl One for mat::Identity {
     #[inline]
@@ -42,43 +41,6 @@ impl Transpose for mat::Identity {
     }
 }
 
-impl<V: Zero> Translation<V> for mat::Identity {
-    #[inline]
-    fn translation(&self) -> V {
-        ::zero()
-    }
-
-    #[inline]
-    fn inv_translation(&self) -> V {
-        ::zero()
-    }
-
-    #[inline]
-    fn append_translation_mut(&mut self, _: &V) {
-        panic!("Attempted to translate the identity matrix.")
-    }
-
-    #[inline]
-    fn append_translation(&self, _: &V) -> mat::Identity {
-        panic!("Attempted to translate the identity matrix.")
-    }
-
-    #[inline]
-    fn prepend_translation_mut(&mut self, _: &V) {
-        panic!("Attempted to translate the identity matrix.")
-    }
-
-    #[inline]
-    fn prepend_translation(&self, _: &V) -> mat::Identity {
-        panic!("Attempted to translate the identity matrix.")
-    }
-
-    #[inline]
-    fn set_translation(&mut self, _: V) {
-        panic!("Attempted to translate the identity matrix.")
-    }
-}
-
 impl<V: Clone> Translate<V> for mat::Identity {
     #[inline]
     fn translate(&self, v: &V) -> V {
@@ -88,43 +50,6 @@ impl<V: Clone> Translate<V> for mat::Identity {
     #[inline]
     fn inv_translate(&self, v: &V) -> V {
         v.clone()
-    }
-}
-
-impl<V: Zero> Rotation<V> for mat::Identity {
-    #[inline]
-    fn rotation(&self) -> V {
-        ::zero()
-    }
-
-    #[inline]
-    fn inv_rotation(&self) -> V {
-        ::zero()
-    }
-
-    #[inline]
-    fn append_rotation_mut(&mut self, _: &V) {
-        panic!("Attempted to rotate the identity matrix.")
-    }
-
-    #[inline]
-    fn append_rotation(&self, _: &V) -> mat::Identity {
-        panic!("Attempted to rotate the identity matrix.")
-    }
-
-    #[inline]
-    fn prepend_rotation_mut(&mut self, _: &V) {
-        panic!("Attempted to rotate the identity matrix.")
-    }
-
-    #[inline]
-    fn prepend_rotation(&self, _: &V) -> mat::Identity {
-        panic!("Attempted to rotate the identity matrix.")
-    }
-
-    #[inline]
-    fn set_rotation(&mut self, _: V) {
-        panic!("Attempted to rotate the identity matrix.")
     }
 }
 
@@ -144,43 +69,6 @@ impl<V: Clone> AbsoluteRotate<V> for mat::Identity {
     #[inline]
     fn absolute_rotate(&self, v: &V) -> V {
         v.clone()
-    }
-}
-
-impl<M: One> Transformation<M> for mat::Identity {
-    #[inline]
-    fn transformation(&self) -> M {
-        ::one()
-    }
-
-    #[inline]
-    fn inv_transformation(&self) -> M {
-        ::one()
-    }
-
-    #[inline]
-    fn append_transformation_mut(&mut self, _: &M) {
-        panic!("Attempted to transform the identity matrix.")
-    }
-
-    #[inline]
-    fn append_transformation(&self, _: &M) -> mat::Identity {
-        panic!("Attempted to transform the identity matrix.")
-    }
-
-    #[inline]
-    fn prepend_transformation_mut(&mut self, _: &M) {
-        panic!("Attempted to transform the identity matrix.")
-    }
-
-    #[inline]
-    fn prepend_transformation(&self, _: &M) -> mat::Identity {
-        panic!("Attempted to transform the identity matrix.")
-    }
-
-    #[inline]
-    fn set_transformation(&mut self, _: M) {
-        panic!("Attempted to transform the identity matrix.")
     }
 }
 


### PR DESCRIPTION
Because most of their methods did not make sence for the (constant) identity transformation, they were set to `panic!` at runtime whenever the user tried to use them. Instead, it is much safer to completely forbid their use by removing the related trait implementation.

See sebcrozet/ncollide#87.