### PR TITLE
Removed Display trait requirement from Debug method for DMat.

### DIFF
--- a/src/structs/dmat.rs
+++ b/src/structs/dmat.rs
@@ -633,11 +633,11 @@ impl<N: ApproxEq<N>> ApproxEq<N> for DMat<N> {
     }
 }
 
-impl<N: Debug + Copy + Display> Debug for DMat<N> {
+impl<N: Debug + Copy> Debug for DMat<N> {
     fn fmt(&self, form:&mut Formatter) -> Result {
         for i in 0..self.nrows() {
             for j in 0..self.ncols() {
-                let _ = write!(form, "{} ", self[(i, j)]);
+                let _ = write!(form, "{:?} ", self[(i, j)]);
             }
             let _ = write!(form, "\n");
         }


### PR DESCRIPTION
DMat was unable to use the Debug trait if the value stored inside did not have the Display trait. This meant it could not be displayed or used in an assertion.