### PR TITLE
Improved QR algorithm convergence

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,8 @@ pub use structs::{
 pub use linalg::{
     qr,
     householder_matrix,
-    cholesky
+    cholesky,
+    hessenberg
 };
 
 mod structs;

--- a/src/linalg/mod.rs
+++ b/src/linalg/mod.rs
@@ -1,4 +1,4 @@
 
-pub use self::decompositions::{qr, eigen_qr, householder_matrix, cholesky};
+pub use self::decompositions::{qr, eigen_qr, householder_matrix, cholesky, hessenberg};
 
 mod decompositions;


### PR DESCRIPTION
I implemented a function that transforms a given matrix to Hessenberg form which allows to efficiently compute the QR decompositions with less operations than with the full Householder approach. Additionally, the Wilkinson shift is introduced to improve the convergence rate.

Unfortunately, this algorithm and the original algorithm can only be used with symmetric matrices since general matrices may possess complex eigenvalues. This case is much more complicated and requires more sophisticated algorithms which can be addressed later.