### PR TITLE
Add Debug trait to Outer trait

### DIFF
--- a/src/structs/mat.rs
+++ b/src/structs/mat.rs
@@ -19,6 +19,7 @@ use traits::geometry::{ToHomogeneous, FromHomogeneous, Orig};
 use linalg;
 #[cfg(feature="arbitrary")]
 use quickcheck::{Arbitrary, Gen};
+use std::fmt::Debug;
 
 
 /// Special identity matrix. All its operation are no-ops.

--- a/src/structs/mat_macros.rs
+++ b/src/structs/mat_macros.rs
@@ -702,7 +702,7 @@ macro_rules! from_homogeneous_impl(
 
 macro_rules! outer_impl(
     ($t: ident, $m: ident) => (
-        impl<N: Copy + Mul<N, Output = N> + Zero> Outer for $t<N> {
+        impl<N: Copy + Debug + Mul<N, Output = N> + Zero> Outer for $t<N> {
             type OuterProductType = $m<N>;
 
             #[inline]

--- a/src/traits/operations.rs
+++ b/src/traits/operations.rs
@@ -4,6 +4,7 @@ use num::{Float, Signed};
 use std::ops::Mul;
 use std::cmp::Ordering;
 use traits::structure::SquareMat;
+use std::fmt::Debug;
 
 /// Result of a partial ordering.
 #[derive(Eq, PartialEq, RustcEncodable, RustcDecodable, Clone, Debug, Copy)]
@@ -300,9 +301,9 @@ pub trait Transpose {
 }
 
 /// Traits of objects having an outer product.
-pub trait Outer {
+pub trait Outer : Debug {
     /// Result type of the outer product.
-    type OuterProductType;
+    type OuterProductType : Debug;
 
     /// Computes the outer product: `a * b`
     fn outer(&self, other: &Self) -> Self::OuterProductType;


### PR DESCRIPTION
This PR is part of the https://github.com/sebcrozet/nphysics/issues/43 issue.
It enables me to use println! debugging in ncollide, for an example see https://github.com/MichaelRiss/ncollide/tree/with_debug_println.

So I thought, maybe this could be useful for somebody else.
But please be careful, this is probably not the right way to do it. I'm a rust newbie and figuring out where to touch the code to route the Debug trait successfully to the place I needed it, was admittedly banging randomly on the code until it finally worked.