### PR TITLE
mat_macros: from_homogeneous_impl was using dimension of src not dst

### DIFF
--- a/src/structs/mat_macros.rs
+++ b/src/structs/mat_macros.rs
@@ -682,8 +682,8 @@ macro_rules! from_homogeneous_impl(
         fn from(m: &$t2<N>) -> $t<N> {
             let mut res: $t<N> = ::one();
 
-            for i in 0..$dim2 {
-                for j in 0..$dim2 {
+            for i in 0..$dim {
+                for j in 0..$dim {
                     res[(i, j)] = m[(i, j)]
                 }
             }


### PR DESCRIPTION
for example:

```rust
let m4: Mat4<f32> = one();
let m3: Mat3<f32> = from_homogeneous(&m4);
```

used 4 as the boundary of the for loop which made it panic