### PR TITLE
Support `f64 * Vec3<f64>` and so on. Fixes #182.

### DIFF
--- a/src/structs/dmat_macros.rs
+++ b/src/structs/dmat_macros.rs
@@ -634,6 +634,36 @@ macro_rules! dmat_impl(
             }
         }
 
+        impl Mul<$dmat<f32>> for f32 {
+            type Output = $dmat<f32>;
+
+            #[inline]
+            fn mul(self, right: $dmat<f32>) -> $dmat<f32> {
+                let mut res = right;
+
+                for mij in res.mij.iter_mut() {
+                    *mij = self * *mij;
+                }
+
+                res
+            }
+        }
+
+        impl Mul<$dmat<f64>> for f64 {
+            type Output = $dmat<f64>;
+
+            #[inline]
+            fn mul(self, right: $dmat<f64>) -> $dmat<f64> {
+                let mut res = right;
+
+                for mij in res.mij.iter_mut() {
+                    *mij = self * *mij;
+                }
+
+                res
+            }
+        }
+
         impl<N: Copy + Div<N, Output = N>> Div<N> for $dmat<N> {
             type Output = $dmat<N>;
 
@@ -658,6 +688,36 @@ macro_rules! dmat_impl(
 
                 for mij in res.mij.iter_mut() {
                     *mij = *mij + right;
+                }
+
+                res
+            }
+        }
+
+        impl Add<$dmat<f32>> for f32 {
+            type Output = $dmat<f32>;
+
+            #[inline]
+            fn add(self, right: $dmat<f32>) -> $dmat<f32> {
+                let mut res = right;
+
+                for mij in res.mij.iter_mut() {
+                    *mij = self + *mij;
+                }
+
+                res
+            }
+        }
+
+        impl Add<$dmat<f64>> for f64 {
+            type Output = $dmat<f64>;
+
+            #[inline]
+            fn add(self, right: $dmat<f64>) -> $dmat<f64> {
+                let mut res = right;
+
+                for mij in res.mij.iter_mut() {
+                    *mij = self + *mij;
                 }
 
                 res
@@ -709,6 +769,36 @@ macro_rules! dmat_impl(
 
                 for mij in res.mij.iter_mut() {
                     *mij = *mij - right;
+                }
+
+                res
+            }
+        }
+
+        impl Sub<$dmat<f32>> for f32 {
+            type Output = $dmat<f32>;
+
+            #[inline]
+            fn sub(self, right: $dmat<f32>) -> $dmat<f32> {
+                let mut res = right;
+
+                for mij in res.mij.iter_mut() {
+                    *mij = self - *mij;
+                }
+
+                res
+            }
+        }
+
+        impl Sub<$dmat<f64>> for f64 {
+            type Output = $dmat<f64>;
+
+            #[inline]
+            fn sub(self, right: $dmat<f64>) -> $dmat<f64> {
+                let mut res = right;
+
+                for mij in res.mij.iter_mut() {
+                    *mij = self - *mij;
                 }
 
                 res

--- a/src/structs/mat_macros.rs
+++ b/src/structs/mat_macros.rs
@@ -118,6 +118,24 @@ macro_rules! mat_mul_scalar_impl(
                 $t::new($(self.$compN * *right),+)
             }
         }
+
+        impl Mul<$t<f32>> for f32 {
+            type Output = $t<f32>;
+
+            #[inline]
+            fn mul(self, right: $t<f32>) -> $t<f32> {
+                $t::new($(self * right.$compN),+)
+            }
+        }
+
+        impl Mul<$t<f64>> for f64 {
+            type Output = $t<f64>;
+
+            #[inline]
+            fn mul(self, right: $t<f64>) -> $t<f64> {
+                $t::new($(self * right.$compN),+)
+            }
+        }
     )
 );
 
@@ -142,6 +160,24 @@ macro_rules! mat_add_scalar_impl(
             #[inline]
             fn add(self, right: N) -> $t<N> {
                 $t::new($(self.$compN + *right),+)
+            }
+        }
+
+        impl Add<$t<f32>> for f32 {
+            type Output = $t<f32>;
+
+            #[inline]
+            fn add(self, right: $t<f32>) -> $t<f32> {
+                $t::new($(self + right.$compN),+)
+            }
+        }
+
+        impl Add<$t<f64>> for f64 {
+            type Output = $t<f64>;
+
+            #[inline]
+            fn add(self, right: $t<f64>) -> $t<f64> {
+                $t::new($(self + right.$compN),+)
             }
         }
     )
@@ -175,12 +211,30 @@ macro_rules! repeat_impl(
 
 macro_rules! mat_sub_scalar_impl(
     ($t: ident, $($compN: ident),+) => (
-        impl<N: Sub<N, Output = N> Sub<N> for $t<N> {
+        impl<N: Sub<N, Output = N>> Sub<N> for $t<N> {
             type Output = $t<N>;
 
             #[inline]
             fn sub(self, right: &N) -> $t<N> {
                 $t::new($(self.$compN - *right),+)
+            }
+        }
+
+        impl Sub<f32> for $t<f32> {
+            type Output = $t<f32>;
+
+            #[inline]
+            fn sub(self, right: $t<f32>) -> $t<f32> {
+                $t::new($(self - right.$compN),+)
+            }
+        }
+
+        impl Sub<f64> for $t<f64> {
+            type Output = $t<f64>;
+
+            #[inline]
+            fn sub(self, right: $t<f64>) -> $t<f64> {
+                $t::new($(self - right.$compN),+)
             }
         }
     )

--- a/src/structs/vec_macros.rs
+++ b/src/structs/vec_macros.rs
@@ -386,6 +386,24 @@ macro_rules! scalar_add_impl(
                 $t::new($(self.$compN + right),+)
             }
         }
+
+        impl Add<$t<f32>> for f32 {
+            type Output = $t<f32>;
+
+            #[inline]
+            fn add(self, right: $t<f32>) -> $t<f32> {
+                $t::new($(self + right.$compN),+)
+            }
+        }
+
+        impl Add<$t<f64>> for f64 {
+            type Output = $t<f64>;
+
+            #[inline]
+            fn add(self, right: $t<f64>) -> $t<f64> {
+                $t::new($(self + right.$compN),+)
+            }
+        }
     )
 );
 
@@ -412,6 +430,24 @@ macro_rules! scalar_sub_impl(
                 $t::new($(self.$compN - right),+)
             }
         }
+
+        impl Sub<$t<f32>> for f32 {
+            type Output = $t<f32>;
+
+            #[inline]
+            fn sub(self, right: $t<f32>) -> $t<f32> {
+                $t::new($(self - right.$compN),+)
+            }
+        }
+
+        impl Sub<$t<f64>> for f64 {
+            type Output = $t<f64>;
+
+            #[inline]
+            fn sub(self, right: $t<f64>) -> $t<f64> {
+                $t::new($(self - right.$compN),+)
+            }
+        }
     )
 );
 
@@ -435,6 +471,24 @@ macro_rules! scalar_mul_impl(
             #[inline]
             fn mul(self, right: N) -> $t<N> {
                 $t::new($(self.$compN * right),+)
+            }
+        }
+
+        impl Mul<$t<f32>> for f32 {
+            type Output = $t<f32>;
+
+            #[inline]
+            fn mul(self, right: $t<f32>) -> $t<f32> {
+                $t::new($(self * right.$compN),+)
+            }
+        }
+
+        impl Mul<$t<f64>> for f64 {
+            type Output = $t<f64>;
+
+            #[inline]
+            fn mul(self, right: $t<f64>) -> $t<f64> {
+                $t::new($(self * right.$compN),+)
             }
         }
     )

--- a/src/structs/vecn_macros.rs
+++ b/src/structs/vecn_macros.rs
@@ -264,6 +264,36 @@ macro_rules! vecn_dvec_common_impl(
             }
         }
 
+        impl<$($param : ArrayLength<N>),*> Mul<$vecn<f32 $(, $param)*>> for f32 {
+            type Output = $vecn<f32 $(, $param)*>;
+
+            #[inline]
+            fn mul(self, right: $vecn<f32 $(, $param)*>) -> $vecn<f32 $(, $param)*> {
+                let mut res = right;
+
+                for e in res.as_mut().iter_mut() {
+                    *e = self * *e;
+                }
+
+                res
+            }
+        }
+
+        impl<$($param : ArrayLength<N>),*> Mul<$vecn<f64 $(, $param)*>> for f64 {
+            type Output = $vecn<f64 $(, $param)*>;
+
+            #[inline]
+            fn mul(self, right: $vecn<f64 $(, $param)*>) -> $vecn<f64 $(, $param)*> {
+                let mut res = right;
+
+                for e in res.as_mut().iter_mut() {
+                    *e = self * *e;
+                }
+
+                res
+            }
+        }
+
         impl<N: Copy + Div<N, Output = N> + Zero $(, $param : ArrayLength<N>)*> Div<N> for $vecn<N $(, $param)*> {
             type Output = $vecn<N $(, $param)*>;
 
@@ -294,6 +324,36 @@ macro_rules! vecn_dvec_common_impl(
             }
         }
 
+        impl<$($param : ArrayLength<f32>),*> Add<$vecn<f32 $(, $param)*>> for f32 {
+            type Output = $vecn<f32 $(, $param)*>;
+
+            #[inline]
+            fn add(self, right: $vecn<f32 $(, $param)*>) -> $vecn<f32 $(, $param)*> {
+                let mut res = right;
+
+                for e in res.as_mut().iter_mut() {
+                    *e = self + *e;
+                }
+
+                res
+            }
+        }
+
+        impl<$($param : ArrayLength<f64>),*> Add<$vecn<f64 $(, $param)*>> for f64 {
+            type Output = $vecn<f64 $(, $param)*>;
+
+            #[inline]
+            fn add(self, right: $vecn<f64 $(, $param)*>) -> $vecn<f64 $(, $param)*> {
+                let mut res = right;
+
+                for e in res.as_mut().iter_mut() {
+                    *e = self + *e;
+                }
+
+                res
+            }
+        }
+
         impl<N: Copy + Sub<N, Output = N> + Zero $(, $param : ArrayLength<N>)*> Sub<N> for $vecn<N $(, $param)*> {
             type Output = $vecn<N $(, $param)*>;
 
@@ -303,6 +363,36 @@ macro_rules! vecn_dvec_common_impl(
 
                 for e in res.as_mut().iter_mut() {
                     *e = *e - right
+                }
+
+                res
+            }
+        }
+
+        impl<$($param : ArrayLength<f32>),*> Sub<$vecn<f32 $(, $param)*>> for f32 {
+            type Output = $vecn<f32 $(, $param)*>;
+
+            #[inline]
+            fn sub(self, right: $vecn<f32 $(, $param)*>) -> $vecn<f32 $(, $param)*> {
+                let mut res = right;
+
+                for e in res.as_mut().iter_mut() {
+                    *e = self - *e;
+                }
+
+                res
+            }
+        }
+
+        impl<$($param : ArrayLength<f64>),*> Sub<$vecn<f64 $(, $param)*>> for f64 {
+            type Output = $vecn<f64 $(, $param)*>;
+
+            #[inline]
+            fn sub(self, right: $vecn<f64 $(, $param)*>) -> $vecn<f64 $(, $param)*> {
+                let mut res = right;
+
+                for e in res.as_mut().iter_mut() {
+                    *e = self - *e;
                 }
 
                 res


### PR DESCRIPTION
To be specific, support is added for `N op T<N>` where `N` is `f32` or `f64`, `op` is one of `+` `-` `*`, and `T` is one of the `Vec`, `DVec`, `Mat`, or `DMat` generic types. These are all cases where `T<N> op N` is already supported.

*   Except for `f32 * Vec3<f32>`, which works fine :) the rest of this is untested.

*   The code I'm touching in `src/mat_macros.rs` seems to be dead code! I can remove it or just leave it alone instead, just let me know what to do...