### PR TITLE
Fix benchmark macro `bench_binop`

### DIFF
--- a/benches/common/macros.rs
+++ b/benches/common/macros.rs
@@ -16,7 +16,7 @@ macro_rules! bench_binop(
                 i = (i + 1) & (LEN - 1);
 
                 unsafe {
-                    test::black_box(elems1.get_unchecked(i).$binop(*elems2.get_unchecked(i)))
+                    test::black_box((*elems1.get_unchecked(i)).$binop(*elems2.get_unchecked(i)))
                 }
             })
         }


### PR DESCRIPTION
Previously, `cargo bench` had been failing out with, (e.g.)

```error[E0277]: the trait bound `&na::Quaternion<f32>: std::ops::Mul<na::Quaternion<f32>>` is not satisfied```