### PR TITLE
Relax invertibility check for Matrix::try_inverse

### DIFF
--- a/src/core/inverse.rs
+++ b/src/core/inverse.rs
@@ -45,18 +45,19 @@ impl<N, D: Dim, S> SquareMatrix<N, D, S>
             match dim {
                 0 => true,
                 1 => {
-                    if relative_eq!(self.get_unchecked(0, 0), &N::zero()) {
+                    let determinant = self.get_unchecked(0, 0).clone();
+                    if determinant == N::zero() {
                         false
                     }
                     else {
-                        *self.get_unchecked_mut(0, 0) = N::one() / self.determinant();
+                        *self.get_unchecked_mut(0, 0) = N::one() / determinant;
                         true
                     }
                 },
                 2 => {
                     let determinant = self.determinant();
 
-                    if relative_eq!(&determinant, &N::zero()) {
+                    if determinant == N::zero() {
                         false
                     }
                     else {
@@ -94,7 +95,7 @@ impl<N, D: Dim, S> SquareMatrix<N, D, S>
                                       m12 * minor_m11_m23 +
                                       m13 * minor_m11_m22;
 
-                    if relative_eq!(&determinant, &N::zero()) {
+                    if determinant == N::zero() {
                         false
                     }
                     else {

--- a/tests/matrix_inverse.rs
+++ b/tests/matrix_inverse.rs
@@ -61,3 +61,61 @@ fn matrix5_try_inverse() {
 
     assert_relative_eq!(a_inv, expected_inverse, max_relative=1e-4);
 }
+
+#[test]
+fn matrix1_try_inverse_scaled_identity() {
+    // A perfectly invertible matrix with
+    // very small coefficients
+    let a = Matrix1::new(1.0e-20);
+    let expected_inverse = Matrix1::new(1.0e20);
+    let a_inv = a.try_inverse().expect("Matrix is invertible");
+
+    assert_relative_eq!(a_inv, expected_inverse);
+}
+
+#[test]
+fn matrix2_try_inverse_scaled_identity() {
+    // A perfectly invertible matrix with
+    // very small coefficients
+    let a = Matrix2::new(1.0e-20,     0.0,
+                             0.0, 1.0e-20);
+    let expected_inverse = Matrix2::new(1.0e20,    0.0,
+                                           0.0, 1.0e20);
+    let a_inv = a.try_inverse().expect("Matrix is invertible");
+
+    assert_relative_eq!(a_inv, expected_inverse);
+}
+
+#[test]
+fn matrix3_try_inverse_scaled_identity() {
+    // A perfectly invertible matrix with
+    // very small coefficients
+    let a = Matrix3::new(1.0e-20,     0.0,     0.0,
+                             0.0, 1.0e-20,     0.0,
+                             0.0,     0.0, 1.0e-20);
+    let expected_inverse = Matrix3::new(1.0e20,    0.0,    0.0,
+                                           0.0, 1.0e20,    0.0,
+                                           0.0,    0.0, 1.0e20);
+    let a_inv = a.try_inverse().expect("Matrix is invertible");
+
+    assert_relative_eq!(a_inv, expected_inverse);
+}
+
+#[test]
+fn matrix5_try_inverse_scaled_identity() {
+    // A perfectly invertible matrix with
+    // very small coefficients
+    let a = Matrix5::new(1.0e-20,     0.0,     0.0,     0.0,     0.0,
+                             0.0, 1.0e-20,     0.0,     0.0,     0.0,
+                             0.0,     0.0, 1.0e-20,     0.0,     0.0,
+                             0.0,     0.0,     0.0, 1.0e-20,     0.0,
+                             0.0,     0.0,     0.0,     0.0, 1.0e-20);
+    let expected_inverse = Matrix5::new(1.0e+20,     0.0,     0.0,     0.0,     0.0,
+                                            0.0, 1.0e+20,     0.0,     0.0,     0.0,
+                                            0.0,     0.0, 1.0e+20,     0.0,     0.0,
+                                            0.0,     0.0,     0.0, 1.0e+20,     0.0,
+                                            0.0,     0.0,     0.0,     0.0, 1.0e+20);;
+    let a_inv = a.try_inverse().expect("Matrix is invertible");
+
+    assert_relative_eq!(a_inv, expected_inverse);
+}

--- a/tests/matrix_inverse.rs
+++ b/tests/matrix_inverse.rs
@@ -1,0 +1,63 @@
+#[macro_use]
+extern crate approx;
+
+extern crate nalgebra as na;
+
+use na::{Matrix1, Matrix2, Matrix3, Matrix5};
+
+#[test]
+fn matrix1_try_inverse() {
+    let a = Matrix1::new(3.0);
+    let a_inv = a.try_inverse().expect("Matrix is invertible");
+
+    assert_relative_eq!(a_inv, Matrix1::new(1.0 / 3.0));
+}
+
+#[test]
+fn matrix2_try_inverse() {
+    let a = Matrix2::new(  5.0,  -2.0,
+                         -10.0,   1.0);
+    let expected_inverse = Matrix2::new(-0.2 / 3.0, -2.0 / 15.0,
+                                        -2.0 / 3.0, -1.0 / 3.0);
+    let a_inv = a.try_inverse()
+                 .expect("Matrix is invertible");
+
+    assert_relative_eq!(a_inv, expected_inverse);
+}
+
+#[test]
+fn matrix3_try_inverse() {
+    let a = Matrix3::new(-3.0,  2.0,  0.0,
+                         -6.0,  9.0, -2.0,
+                          9.0, -6.0,  4.0);
+    let expected_inverse = Matrix3::new(-0.40, 0.4 / 3.0, 0.2 / 3.00,
+                                        -0.10,       0.2,       0.10,
+                                         0.75,       0.0,       0.25);
+    let a_inv = a.try_inverse()
+                 .expect("Matrix is invertible");
+
+    assert_relative_eq!(a_inv, expected_inverse);
+}
+
+#[test]
+fn matrix5_try_inverse() {
+    // Dimension 5 is chosen so that the inversion
+    // happens by Gaussian elimination
+    // (at the time of writing dimensions <= 3 are implemented
+    //  as analytic formulas, but we choose 5 in the case that 4
+    //  also gets an analytic implementation)
+    let a = Matrix5::new(-2.0,   0.0,   2.0,   5.0,  -5.0,
+                         -6.0,   4.0,   4.0,  13.0, -15.0,
+                          4.0,  16.0, -14.0, -19.0,  12.0,
+                         12.0,  12.0, -22.0, -35.0,  34.0,
+                         -8.0,   4.0,  12.0,  27.0, -31.0);
+    let expected_inverse = Matrix5::new(
+        3.9333e+00,  -1.5667e+00,   2.6667e-01,   6.6667e-02,  3.0000e-01,
+       -1.2033e+01,   3.9667e+00,  -1.1167e+00,   2.8333e-01, -1.0000e-01,
+       -1.8233e+01,   5.7667e+00,  -1.5667e+00,   2.3333e-01, -2.0000e-01,
+       -4.3333e+00,   1.6667e+00,  -6.6667e-01,   3.3333e-01, -4.6950e-19,
+       -1.3400e+01,   4.6000e+00,  -1.4000e+00,   4.0000e-01, -2.0000e-01);
+    let a_inv = a.try_inverse().expect("Matrix is invertible");
+
+    assert_relative_eq!(a_inv, expected_inverse, max_relative=1e-4);
+}


### PR DESCRIPTION
Resolves #244. I couldn't find any existing tests for `try_inverse` at all, so I took the liberty to add some very basic tests for a single example of a few different dimensions. Let me know if you don't want them!