### PR TITLE
Remove gratuitous indirection in serialization impls

### DIFF
--- a/src/core/dimension.rs
+++ b/src/core/dimension.rs
@@ -7,9 +7,11 @@ use std::any::Any;
 use std::ops::{Add, Sub, Mul, Div};
 use typenum::{self, Unsigned, UInt, B1, Bit, UTerm, Sum, Prod, Diff, Quot};
 
+#[cfg(feature = "serde-serialize")]
+use serde::{Serialize, Serializer, Deserialize, Deserializer};
+
 /// Dim of dynamically-sized algebraic entities.
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
-#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 pub struct Dynamic {
     value: usize
 }
@@ -21,6 +23,24 @@ impl Dynamic {
         Dynamic {
             value: value
         }
+    }
+}
+
+#[cfg(feature = "serde-serialize")]
+impl Serialize for Dynamic {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: Serializer
+    {
+        self.value.serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde-serialize")]
+impl<'de> Deserialize<'de> for Dynamic {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: Deserializer<'de>
+    {
+        usize::deserialize(deserializer).map(|x| Dynamic { value: x })
     }
 }
 

--- a/src/core/unit.rs
+++ b/src/core/unit.rs
@@ -2,6 +2,9 @@ use std::mem;
 use std::ops::{Neg, Deref};
 use approx::ApproxEq;
 
+#[cfg(feature = "serde-serialize")]
+use serde::{Serialize, Serializer, Deserialize, Deserializer};
+
 use alga::general::SubsetOf;
 use alga::linear::NormedSpace;
 
@@ -11,9 +14,26 @@ use alga::linear::NormedSpace;
 /// Use `.as_ref()` or `.unwrap()` to obtain the undelying value by-reference or by-move.
 #[repr(C)]
 #[derive(Eq, PartialEq, Clone, Hash, Debug, Copy)]
-#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 pub struct Unit<T> {
     value: T
+}
+
+#[cfg(feature = "serde-serialize")]
+impl<T: Serialize> Serialize for Unit<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: Serializer
+    {
+        self.value.serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde-serialize")]
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for Unit<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: Deserializer<'de>
+    {
+        T::deserialize(deserializer).map(|x| Unit { value: x })
+    }
 }
 
 impl<T: NormedSpace> Unit<T> {

--- a/src/geometry/orthographic.rs
+++ b/src/geometry/orthographic.rs
@@ -2,6 +2,9 @@
 use quickcheck::{Arbitrary, Gen};
 use rand::{Rand, Rng};
 
+#[cfg(feature = "serde-serialize")]
+use serde::{Serialize, Serializer, Deserialize, Deserializer};
+
 use alga::general::Real;
 
 use core::{Scalar, SquareMatrix, OwnedSquareMatrix, ColumnVector, OwnedColumnVector, MatrixArray};
@@ -14,9 +17,34 @@ use geometry::{PointBase, OwnedPoint};
 
 /// A 3D orthographic projection stored as an homogeneous 4x4 matrix.
 #[derive(Debug, Clone, Copy)] // FIXME: Hash
-#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 pub struct OrthographicBase<N: Scalar, S: Storage<N, U4, U4>> {
     matrix: SquareMatrix<N, U4, S>
+}
+
+#[cfg(feature = "serde-serialize")]
+impl<N, S> Serialize for OrthographicBase<N, S>
+    where N: Scalar,
+          S: Storage<N, U4, U4>,
+          SquareMatrix<N, U4, S>: Serialize,
+{
+    fn serialize<T>(&self, serializer: T) -> Result<T::Ok, T::Error>
+        where T: Serializer
+    {
+        self.matrix.serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde-serialize")]
+impl<'de, N, S> Deserialize<'de> for OrthographicBase<N, S>
+    where N: Scalar,
+          S: Storage<N, U4, U4>,
+          SquareMatrix<N, U4, S>: Deserialize<'de>,
+{
+    fn deserialize<T>(deserializer: T) -> Result<Self, T::Error>
+        where T: Deserializer<'de>
+    {
+        SquareMatrix::deserialize(deserializer).map(|x| OrthographicBase { matrix: x })
+    }
 }
 
 /// A 3D orthographic projection stored as a static homogeneous 4x4 matrix.

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -13,7 +13,8 @@ use na::{
     IsometryMatrix3,
     Similarity3,
     SimilarityMatrix3,
-    Quaternion
+    Quaternion,
+    Unit,
 };
 
 macro_rules! test_serde(
@@ -45,3 +46,11 @@ test_serde!(
     serde_similarity_matrix3, SimilarityMatrix3;
     serde_quaternion,         Quaternion;
 );
+
+#[test]
+fn serde_flat() {
+    // The actual storage is hidden behind three layers of wrapper types that shouldn't appear in serialized form.
+    let v = Unit::new_normalize(Quaternion::new(0., 0., 0., 1.));
+    let serialized = serde_json::to_string(&v).unwrap();
+    assert_eq!(serialized, "[0.0,0.0,1.0,0.0]");
+}


### PR DESCRIPTION
I think I got everything; let me know if not.

I deliberately passed on intelligent handling of nrows/ncols in `MatrixVec` for now because it seems considerably less trivial.

In the future, these impls could be replaced by a macro, or better yet, attribute-based support in serde for forwarding implementations.

Fixes #249