### PR TITLE
Enable serde on num-complex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 
 [features]
 arbitrary = [ "quickcheck" ]
-serde-serialize = [ "serde", "serde_derive" ]
+serde-serialize = [ "serde", "serde_derive", "num-complex/serde" ]
 
 [dependencies]
 typenum         = "1.4"


### PR DESCRIPTION
I needed this to serialise `UnitComplex`.  Does it seem reasonable?