### PR TITLE
Fix spelling of "below" in gh-pages

### DIFF
--- a/docs/decompositions_and_lapack.md
+++ b/docs/decompositions_and_lapack.md
@@ -131,7 +131,7 @@ Method                   | Effect
 ## Hessenberg decomposition
 The hessenberg decomposition of a square matrix $M$ is composed of an orthogonal
 matrix $Q$ and an upper-Hessenberg matrix $H$ such that $M = QHQ^*$. The matrix
-$H$ being upper-Hessenberg means that all components bellow its first
+$H$ being upper-Hessenberg means that all components below its first
 subdiagonal are zero. See also [the wikipedia
 article](https://en.wikipedia.org/wiki/Hessenberg_matrix) for further details.
 
@@ -212,7 +212,7 @@ that `v_t` represents the transpose of the matrix $V$.
 Method                 | Effect
 -----------------------|-----------
 `.recompose()`         | Reconstructs the matrix from its decomposition. Useful if some singular values or singular vectors have been manually modified.
-`.pseudo_inverse(eps)` | Computes the pseudo-inverse of the decomposed matrix. All singular values bellow `eps` will be interpreted as equal to zero.
+`.pseudo_inverse(eps)` | Computes the pseudo-inverse of the decomposed matrix. All singular values below `eps` will be interpreted as equal to zero.
 `.rank(eps)`           | Computes the rank of the decomposed matrix, i.e., the number of singular values strictly greater than `eps`.
 `.solve(b, eps)`       | Solves the linear system $Ax = b$ where $A$ is the decomposed square matrix and $x$ the unkonwn. All singular value smaller or equal to `eps` are interpreted as zero.
 

--- a/docs/quick_reference.md
+++ b/docs/quick_reference.md
@@ -126,7 +126,7 @@ compile-time of the matrix being created.
 `.copy_from(matrix)`          <span style="float:right;">Copies the content of another matrix with the same shape.</span><br/>
 `.fill(value)`                <span style="float:right;">Sets all components to `value`.</span><br/>
 `.fill_diagonal(value)`       <span style="float:right;">Fills the matrix diagonal with a single value.</span><br/>
-`.fill_lower_triangle(value)` <span style="float:right;">Fills some sub-diagonals bellow the main diagonal with a value.</span><br/>
+`.fill_lower_triangle(value)` <span style="float:right;">Fills some sub-diagonals below the main diagonal with a value.</span><br/>
 `.fill_upper_triangle(value)` <span style="float:right;">Fills some sub-diagonals above the main diagonal with a value.</span><br/>
 `.map(f)`                     <span style="float:right;">Applies `f` to each component and stores the results on a new matrix.</span><br/>
 `.apply(f)`                   <span style="float:right;">Applies in-place `f` to each component of the matrix.</span><br/>

--- a/docs/vectors_and_matrices.md
+++ b/docs/vectors_and_matrices.md
@@ -109,7 +109,7 @@ let m = Matrix3x4::new(11, 12, 13, 14,
 ```
 
 Depending on the values of the `R` and `C` type parameters for the matrix
-shape, the matrix construction methods listed bellow may have different
+shape, the matrix construction methods listed below may have different
 signatures. In particular, each constructor takes one `usize` parameter for
 each matrix dimension that is set to `Dynamic`. Specifically:
 


### PR DESCRIPTION
"Below" should only have one 'L' in it (this also occurs in the autogenerated rust docs, but that requires a separate PR against master to be fixed).