### PR TITLE
Fix spelling of "below" (in method documentation)

### DIFF
--- a/nalgebra-lapack/src/svd.rs
+++ b/nalgebra-lapack/src/svd.rs
@@ -163,7 +163,7 @@ macro_rules! svd_impl(
 
             /// Computes the pseudo-inverse of the decomposed matrix.
             ///
-            /// All singular value bellow epsilon will be set to zero instead of being inverted.
+            /// All singular value below epsilon will be set to zero instead of being inverted.
             #[inline]
             pub fn pseudo_inverse(&self, epsilon: $t) -> MatrixMN<$t, C, R> {
                 let nrows           = self.u.data.shape().0;

--- a/src/core/blas.rs
+++ b/src/core/blas.rs
@@ -70,7 +70,7 @@ impl<N, R: Dim, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S>
 
 
         // So we do some special cases for common fixed-size vectors of dimension lower than 8
-        // because the `for` loop bellow won't be very efficient on those.
+        // because the `for` loop below won't be very efficient on those.
         if (R::is::<U2>() || R2::is::<U2>()) &&
            (C::is::<U1>() || C2::is::<U1>()) {
             unsafe {

--- a/src/geometry/quaternion.rs
+++ b/src/geometry/quaternion.rs
@@ -410,7 +410,7 @@ impl<N: Real> UnitQuaternion<N> {
     /// * `self`: the first quaternion to interpolate from.
     /// * `other`: the second quaternion to interpolate toward.
     /// * `t`: the interpolation parameter. Should be between 0 and 1.
-    /// * `epsilon`: the value bellow which the sinus of the angle separating both quaternion
+    /// * `epsilon`: the value below which the sinus of the angle separating both quaternion
     /// must be to return `None`.
     #[inline]
     pub fn try_slerp(&self, other: &UnitQuaternion<N>, t: N, epsilon: N) -> Option<UnitQuaternion<N>> {

--- a/src/linalg/svd.rs
+++ b/src/linalg/svd.rs
@@ -253,9 +253,9 @@ impl<N: Real, R: DimMin<C>, C: Dim> SVD<N, R, C>
         let denom = (m11 + m22).hypot(m12) + (m11 - m22).hypot(m12);
 
         // NOTE: v1 is the singular value that is the closest to m22.
-        // This prevents cancellation issues when constructing the vector `csv` bellow. If we chose
-        // otherwise, we would have v1 ~= m11 when m12 is small. This would cause catastrofic
-        // cancellation on `v1 * v1 - m11 * m11` bellow.
+        // This prevents cancellation issues when constructing the vector `csv` below. If we chose
+        // otherwise, we would have v1 ~= m11 when m12 is small. This would cause catastrophic
+        // cancellation on `v1 * v1 - m11 * m11` below.
         let v1 = two * m11 * m22 / denom;
         let v2 = half * denom;
 
@@ -543,7 +543,7 @@ impl<N: Real, R: DimMin<C>, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S>
 
     /// Computes the rank of this matrix.
     ///
-    /// All singular values bellow `eps` are considered equal to 0.
+    /// All singular values below `eps` are considered equal to 0.
     pub fn rank(&self, eps: N) -> usize {
         let svd = SVD::new(self.clone_owned(), false, false);
         svd.rank(eps)
@@ -551,7 +551,7 @@ impl<N: Real, R: DimMin<C>, C: Dim, S: Storage<N, R, C>> Matrix<N, R, C, S>
 
     /// Computes the pseudo-inverse of this matrix.
     ///
-    /// All singular values bellow `eps` are considered equal to 0.
+    /// All singular values below `eps` are considered equal to 0.
     pub fn pseudo_inverse(self, eps: N) -> MatrixMN<N, C, R>
         where DefaultAllocator: Allocator<N, C, R> {
 


### PR DESCRIPTION
Counterpart to #296 - this fixes typos in the method documentation (I also fixed some code comments that don't get picked up by rustdoc - I apologize if doing so comes off as nitpicking).