### PR TITLE
Insert missing `</div>` after code snippet in 'Points and Transformations' guide.

### DIFF
--- a/docs/points_and_transformations.md
+++ b/docs/points_and_transformations.md
@@ -109,6 +109,7 @@ assert_eq!(p0, p1);
 assert_eq!(p0, p2);
 assert_eq!(p0, p3);
 ```
+  </div>
 </div>
 
 


### PR DESCRIPTION
The missing `</div>` was borking the markdown for the 'Transformations' section of the guide. 

This fixes #322.