### PR TITLE
disable `rustc-serialize` for `wasm32-unknown-unknown` target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ typenum        = "1.7"
 generic-array  = "0.8"
 rand           = "0.4"
 num-traits     = "0.1"
-num-complex    = "0.1"
+num-complex    = { version = "0.1", default-features = false }
 approx         = "0.1"
 alga           = "0.5"
 matrixmultiply = "0.1"


### PR DESCRIPTION
When build `nalgebra` for `wasm32-unknown-unknown` target, it failed on `rustc-serialize`, we may disable it by default.