### PR TITLE
Changed loops order in from_fn_generic

### DIFF
--- a/benches/core/matrix.rs
+++ b/benches/core/matrix.rs
@@ -192,7 +192,7 @@ fn mat100_from_fn(bench: &mut Bencher) {
     bench.iter(|| {
         DMatrix::from_fn(100, 100, |a, b| {
             a + b
-        });
+        })
     })
 }
 
@@ -201,6 +201,6 @@ fn mat500_from_fn(bench: &mut Bencher) {
     bench.iter(|| {
         DMatrix::from_fn(500, 500, |a, b| {
             a + b
-        });
+        })
     })
 }

--- a/benches/core/matrix.rs
+++ b/benches/core/matrix.rs
@@ -186,3 +186,21 @@ fn mat_mul_mat(bench: &mut Bencher) {
         test::black_box(a.mul_to(&b, &mut ab));
     })
 }
+
+#[bench]
+fn mat100_from_fn(bench: &mut Bencher) {
+    bench.iter(|| {
+        DMatrix::from_fn(100, 100, |a, b| {
+            a + b
+        });
+    })
+}
+
+#[bench]
+fn mat500_from_fn(bench: &mut Bencher) {
+    bench.iter(|| {
+        DMatrix::from_fn(500, 500, |a, b| {
+            a + b
+        });
+    })
+}

--- a/src/base/construction.rs
+++ b/src/base/construction.rs
@@ -108,8 +108,8 @@ where
     {
         let mut res = unsafe { Self::new_uninitialized_generic(nrows, ncols) };
 
-        for i in 0..nrows.value() {
-            for j in 0..ncols.value() {
+        for j in 0..ncols.value() {
+            for i in 0..nrows.value() {
                 unsafe { *res.get_unchecked_mut(i, j) = f(i, j) }
             }
         }


### PR DESCRIPTION
Hi!

First, thank you for your librairies, they are great!

After investigating the performances of [the code from a friend on the forum](https://discourse.nphysics.org/t/efficient-ways-of-computing-a-centered-gradient/204), I realized that the `from_fn` function was quite slow due to the fact that matrices are stored by columns, but the iteration is done by rows.

I also added a benchmark to see the performance improvements:

Original version:
```
test core::matrix::mat100_from_fn :     7,736 ns/iter (+/- 246)
test core::matrix::mat500_from_fn : 1,085,050 ns/iter (+/- 192,820)
```

This PR version:
```
test core::matrix::mat100_from_fn:   2,796 ns/iter (+/- 189)
test core::matrix::mat500_from_fn: 650,736 ns/iter (+/- 16,264)
```