### PR TITLE
Uniformly distributed random rotations, unit vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ documented here.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.16.0] - WIP
+## Modified
+  * Adjust `UnitQuaternion`s and `Rotation3`s generated from the `Standard` distribution to be uniformly distributed.
 ### Added
   * Add construction of a `Point` from an array by implementing the `From` trait.
+  * Add support for generating uniformly distributed random unit column vectors using the `Standard` distribution.
 
 ## [0.15.0]
 The most notable change of this release is the support for using part of the library without the rust standard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.16.0] - WIP
 ## Modified
-  * Adjust `UnitQuaternion`s and `Rotation3`s generated from the `Standard` distribution to be uniformly distributed.
+  * Adjust `UnitQuaternion`s, `Rotation3`s, and `Rotation2`s generated from the `Standard` distribution to be uniformly
+    distributed.
 ### Added
   * Add construction of a `Point` from an array by implementing the `From` trait.
   * Add support for generating uniformly distributed random unit column vectors using the `Standard` distribution.

--- a/src/base/construction.rs
+++ b/src/base/construction.rs
@@ -5,7 +5,7 @@ use quickcheck::{Arbitrary, Gen};
 
 use num::{Bounded, One, Zero};
 #[cfg(feature = "std")]
-use rand::{self, StandardNormal};
+use rand::{self, distributions::StandardNormal};
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 use std::iter;

--- a/src/base/construction.rs
+++ b/src/base/construction.rs
@@ -6,12 +6,12 @@ use quickcheck::{Arbitrary, Gen};
 use num::{Bounded, One, Zero};
 #[cfg(feature = "std")]
 use rand;
-use rand::distributions::{Distribution, Standard};
+use rand::distributions::{Distribution, Standard, StandardNormal};
 use rand::Rng;
 use std::iter;
 use typenum::{self, Cmp, Greater};
 
-use alga::general::{ClosedAdd, ClosedMul};
+use alga::general::{ClosedAdd, ClosedMul, Real};
 
 use base::allocator::Allocator;
 use base::dimension::{Dim, DimName, Dynamic, U1, U2, U3, U4, U5, U6};
@@ -500,6 +500,19 @@ where
         })
     }
 }
+
+#[cfg(feature = "std")]
+impl<N: Real, D: DimName> Distribution<Unit<VectorN<N, D>>> for Standard
+where
+    DefaultAllocator: Allocator<N, D>,
+    StandardNormal: Distribution<N>,
+{
+    #[inline]
+    fn sample<'a, G: Rng + ?Sized>(&self, rng: &'a mut G) -> Unit<VectorN<N, D>> {
+        Unit::new_normalize(VectorN::from_distribution_generic(D::name(), U1, &mut StandardNormal, rng))
+    }
+}
+
 
 /*
  *

--- a/src/base/construction.rs
+++ b/src/base/construction.rs
@@ -5,8 +5,8 @@ use quickcheck::{Arbitrary, Gen};
 
 use num::{Bounded, One, Zero};
 #[cfg(feature = "std")]
-use rand;
-use rand::distributions::{Distribution, Standard, StandardNormal};
+use rand::{self, StandardNormal};
+use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 use std::iter;
 use typenum::{self, Cmp, Greater};

--- a/src/base/construction.rs
+++ b/src/base/construction.rs
@@ -507,6 +507,7 @@ where
     DefaultAllocator: Allocator<N, D>,
     StandardNormal: Distribution<N>,
 {
+    /// Generate a uniformly distributed random unit vector.
     #[inline]
     fn sample<'a, G: Rng + ?Sized>(&self, rng: &'a mut G) -> Unit<VectorN<N, D>> {
         Unit::new_normalize(VectorN::from_distribution_generic(D::name(), U1, &mut StandardNormal, rng))

--- a/src/geometry/quaternion_construction.rs
+++ b/src/geometry/quaternion_construction.rs
@@ -415,6 +415,7 @@ impl<N: Real> Distribution<UnitQuaternion<N>> for Standard
 where
     OpenClosed01: Distribution<N>,
 {
+    /// Generate a uniformly distributed random rotation quaternion.
     #[inline]
     fn sample<'a, R: Rng + ?Sized>(&self, rng: &'a mut R) -> UnitQuaternion<N> {
         // Ken Shoemake's Subgroup Algorithm

--- a/src/geometry/rotation_specialization.rs
+++ b/src/geometry/rotation_specialization.rs
@@ -100,11 +100,12 @@ impl<N: Real> Rotation2<N> {
 
 impl<N: Real> Distribution<Rotation2<N>> for Standard
 where
-    Standard: Distribution<N>,
+    OpenClosed01: Distribution<N>,
 {
+    /// Generate a uniformly distributed random rotation.
     #[inline]
     fn sample<'a, R: Rng + ?Sized>(&self, rng: &'a mut R) -> Rotation2<N> {
-        Rotation2::new(rng.gen())
+        Rotation2::new(rng.sample(OpenClosed01) * N::two_pi())
     }
 }
 
@@ -386,6 +387,7 @@ impl<N: Real> Distribution<Rotation3<N>> for Standard
 where
     OpenClosed01: Distribution<N>,
 {
+    /// Generate a uniformly distributed random rotation.
     #[inline]
     fn sample<'a, R: Rng + ?Sized>(&self, rng: &mut R) -> Rotation3<N> {
         // James Arvo.

--- a/src/geometry/unit_complex_construction.rs
+++ b/src/geometry/unit_complex_construction.rs
@@ -3,7 +3,7 @@ use quickcheck::{Arbitrary, Gen};
 
 use num::One;
 use num_complex::Complex;
-use rand::distributions::{Distribution, Standard};
+use rand::distributions::{Distribution, Standard, OpenClosed01};
 use rand::Rng;
 
 use alga::general::Real;
@@ -153,11 +153,12 @@ impl<N: Real> One for UnitComplex<N> {
 
 impl<N: Real> Distribution<UnitComplex<N>> for Standard
 where
-    Standard: Distribution<N>,
+    OpenClosed01: Distribution<N>,
 {
+    /// Generate a uniformly distributed random `UnitComplex`.
     #[inline]
     fn sample<'a, R: Rng + ?Sized>(&self, rng: &mut R) -> UnitComplex<N> {
-        UnitComplex::from_angle(rng.gen() * N::two_pi())
+        UnitComplex::from_angle(rng.sample(OpenClosed01) * N::two_pi())
     }
 }
 


### PR DESCRIPTION
This replaces the presumably non-uniform `Standard` distribution implementations for `UnitQuaternion` and `Rotation3` with uniform sampling algorithms taken from Graphics Gems III. While I was at it I also dropped in an implementation for `Unit<VectorN>`.

The implementation bounds for the pre-existing distributions were modified to replace `Standard` with `OpenClosed01`, which is arguably a breaking change. Although this is approximately a no-op for f32/f64, it's unclear what `Standard` might mean for more exotic types, and hence I feel it's appropriate to make the requirements of the algorithms used more explicit.

An alternative approach would be to introduce one or more new unit structs implementing `Distribution` for these algorithms, preserving the pre-existing `Standard` impls for backwards compatibility. This would also have the benefit of providing a clearer point to hang documentation off of, and making code that relies on the uniformity guarantee clearer. On the other hand, a non-uniform `Standard` distribution for these types strikes me as a landmine: users will invariably either want uniformity or a specific non-uniformity best accomplished with a documented or custom distribution.