### PR TITLE
Fix compilation of test when arbitrary is enabled but not `debug`.

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -5,6 +5,7 @@ set -ev
 if [ -z "$NO_STD" ]; then
     if [ -z "$LAPACK" ]; then
         cargo test --verbose;
+        cargo test --verbose "arbitrary";
         cargo test --verbose "debug arbitrary mint serde-serialize abomonation-serialize";
     else
         cd nalgebra-lapack; cargo test --verbose;

--- a/tests/linalg/cholesky.rs
+++ b/tests/linalg/cholesky.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "arbitrary")]
+#![cfg(all(feature = "arbitrary", feature = "debug"))]
 
 use std::cmp;
 use na::{DMatrix, Matrix4x3, DVector, Vector4};


### PR DESCRIPTION
Fix #383 .